### PR TITLE
HTBHF-855 Returning a consistent householdIdentifier based on nino

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '2.1.0.RELEASE'
+        springBootVersion = '2.1.2.RELEASE'
         junitVersion = '5.3.2'
     }
     dependencies {

--- a/manifest.yml
+++ b/manifest.yml
@@ -9,3 +9,6 @@ applications:
     - route: htbhf-smart-stub((app-suffix)).apps.internal
   env:
     JBP_CONFIG_OPEN_JDK_JRE: '{jre: { version: 11.+ }}'
+  services:
+    - logit-ssl-drain
+    - variable-service

--- a/src/main/java/uk/gov/dhsc/htbhf/smartstub/model/BenefitDTO.java
+++ b/src/main/java/uk/gov/dhsc/htbhf/smartstub/model/BenefitDTO.java
@@ -23,5 +23,5 @@ public class BenefitDTO {
     private final Integer numberOfChildrenUnderFour;
 
     @JsonProperty("householdIdentifier")
-    private final String householdIdentifier = UUID.randomUUID().toString();
+    private final String householdIdentifier;
 }

--- a/src/main/java/uk/gov/dhsc/htbhf/smartstub/service/BenefitsService.java
+++ b/src/main/java/uk/gov/dhsc/htbhf/smartstub/service/BenefitsService.java
@@ -1,5 +1,6 @@
 package uk.gov.dhsc.htbhf.smartstub.service;
 
+import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import uk.gov.dhsc.htbhf.smartstub.model.BenefitDTO;
 import uk.gov.dhsc.htbhf.smartstub.model.EligibilityStatus;
@@ -16,6 +17,7 @@ import static uk.gov.dhsc.htbhf.smartstub.model.EligibilityStatus.PENDING;
  * See README.md for details on mappings.
  */
 @Service
+@AllArgsConstructor
 public class BenefitsService {
 
     private static final String INVALID_CHILDREN_NUMBER = "Can not have more children under one than children four. Given values were %d, %d";
@@ -23,6 +25,8 @@ public class BenefitsService {
     private static final int CHILDREN_UNDER_ONE_POSITION = 2;
     private static final int CHILDREN_UNDER_FOUR_POSITION = 3;
     private static final Map<Character, EligibilityStatus> ELIGIBILITY_STATUS_MAP = Map.of('E', ELIGIBLE, 'I', INELIGIBLE, 'P', PENDING);
+
+    private final IdentifierService identifierService;
 
     public BenefitDTO getBenefits(char[] nino) {
         var status = ELIGIBILITY_STATUS_MAP.getOrDefault(nino[ELIGIBILITY_STATUS_POSITION], NOMATCH);
@@ -37,10 +41,13 @@ public class BenefitsService {
             throw new IllegalArgumentException(String.format(INVALID_CHILDREN_NUMBER, childrenUnderOne, childrenUnderFour));
         }
 
+        String householdIdentifier = identifierService.getHouseholdIdentifier(new String(nino));
+
         return BenefitDTO.builder()
                 .eligibilityStatus(status)
                 .numberOfChildrenUnderOne(childrenUnderOne)
                 .numberOfChildrenUnderFour(childrenUnderFour)
+                .householdIdentifier(householdIdentifier)
                 .build();
     }
 

--- a/src/main/java/uk/gov/dhsc/htbhf/smartstub/service/IdentifierService.java
+++ b/src/main/java/uk/gov/dhsc/htbhf/smartstub/service/IdentifierService.java
@@ -1,0 +1,15 @@
+package uk.gov.dhsc.htbhf.smartstub.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.Base64;
+
+@Service
+public class IdentifierService {
+
+    private final Base64.Encoder encoder = Base64.getEncoder();
+
+    public String getHouseholdIdentifier(String nino) {
+        return encoder.encodeToString((nino + "-").getBytes());
+    }
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/service/BenefitsServiceTest.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/service/BenefitsServiceTest.java
@@ -18,7 +18,7 @@ import static uk.gov.dhsc.htbhf.smartstub.model.EligibilityStatus.PENDING;
 
 class BenefitsServiceTest {
 
-    private BenefitsService benefitsService = new BenefitsService();
+    private BenefitsService benefitsService = new BenefitsService(new IdentifierService());
 
     @Test
     void shouldReturnIneligibleForMatchingNino() {

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/service/IdentifierServiceTest.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/service/IdentifierServiceTest.java
@@ -1,0 +1,31 @@
+package uk.gov.dhsc.htbhf.smartstub.service;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IdentifierServiceTest {
+
+    IdentifierService service = new IdentifierService();
+
+    @Test
+    void shouldGenerateIdentifierFromNino() {
+        String nino = "QQ123456A";
+        String expected = Base64.getEncoder().encodeToString((nino + "-").getBytes());
+
+        String result = service.getHouseholdIdentifier(nino);
+
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void shouldGenerateIdentifierWhenNoNinoProvided() {
+        String expected = Base64.getEncoder().encodeToString("null-".getBytes());
+
+        String result = service.getHouseholdIdentifier(null);
+
+        assertThat(result).isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
Current thinking is that the householdIdentifier will be a concatenation of the 2 ninos (both partners, sorted), separated by a hyphen and base 64 encoded.