### PR TITLE
NOJIRA Fixing matching rules.

### DIFF
--- a/src/main/java/uk/gov/dhsc/htbhf/smartstub/service/BenefitsService.java
+++ b/src/main/java/uk/gov/dhsc/htbhf/smartstub/service/BenefitsService.java
@@ -68,11 +68,17 @@ public class BenefitsService {
 
     private EligibilityStatus getEligibilityStatus(char[] ninoChars) {
         // Either of the first two characters can be used to determine eligibility. If the first character maps to NO_MATCH, then check the second character.
-        EligibilityStatus status = ELIGIBILITY_STATUS_MAP.getOrDefault(ninoChars[DWP_ELIGIBILITY_STATUS_FIRST_POSITION], NO_MATCH);
-        if (status == NO_MATCH) {
-            return ELIGIBILITY_STATUS_MAP.getOrDefault(ninoChars[DWP_ELIGIBILITY_STATUS_SECOND_POSITION], NO_MATCH);
+        EligibilityStatus firstPositionStatus = ELIGIBILITY_STATUS_MAP.getOrDefault(ninoChars[DWP_ELIGIBILITY_STATUS_FIRST_POSITION], NO_MATCH);
+        EligibilityStatus secondPositionStatus = ELIGIBILITY_STATUS_MAP.getOrDefault(ninoChars[DWP_ELIGIBILITY_STATUS_SECOND_POSITION], NO_MATCH);
+        if (firstPositionStatus == ELIGIBLE || secondPositionStatus == ELIGIBLE){
+            return ELIGIBLE;
+        } else if (firstPositionStatus == INELIGIBLE || secondPositionStatus == INELIGIBLE){
+            return INELIGIBLE;
+        } else if (firstPositionStatus == PENDING || secondPositionStatus == PENDING){
+            return PENDING;
         }
-        return status;
+
+        return NO_MATCH;
     }
 
     private List<ChildDTO> createChildren(Integer numberOfChildrenUnderOne, Integer numberOfChildrenUnderFour) {

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/helper/PersonTestFactory.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/helper/PersonTestFactory.java
@@ -24,14 +24,6 @@ public class PersonTestFactory {
     }
 
     /**
-     * Creates a {@link PersonDTO} request object with a nino that encodes to a person who is ineligible according to DWP (Second character is 'I').
-     */
-    public static PersonDTO anAlternatePersonWhoIsDWPIneligible() {
-        final String nino = "AI000000C";
-        return buildDefaultPerson().nino(nino).build();
-    }
-
-    /**
      * Creates a {@link PersonDTO} request object with a nino that encodes to a person who is eligible according to DWP (First character is 'E').
      */
     public static PersonDTO aPersonWhoIsDWPEligible() {
@@ -40,26 +32,10 @@ public class PersonTestFactory {
     }
 
     /**
-     * Creates a {@link PersonDTO} request object with a nino that encodes to a person who is eligible according to DWP (Second character is 'E').
-     */
-    public static PersonDTO anAlternatePersonWhoIsDWPEligible() {
-        final String nino = "AE000000C";
-        return buildDefaultPerson().nino(nino).build();
-    }
-
-    /**
      * Creates a {@link PersonDTO} request object with a nino that encodes to a person who is pending according to DWP (First character is 'P').
      */
     public static PersonDTO aPersonWhoIsDWPPending() {
         final String nino = "PA000000C";
-        return buildDefaultPerson().nino(nino).build();
-    }
-
-    /**
-     * Creates a {@link PersonDTO} request object with a nino that encodes to a person who is pending according to DWP (Second character is 'P').
-     */
-    public static PersonDTO anAlternatePersonWhoIsDWPPending() {
-        final String nino = "AP000000C";
         return buildDefaultPerson().nino(nino).build();
     }
 
@@ -129,6 +105,13 @@ public class PersonTestFactory {
      */
     public static PersonDTO aPersonWithAnInvalidNino() {
         return buildDefaultPerson().nino("ab123").build();
+    }
+
+    /**
+     * Creates a {@link PersonDTO} request object with the given nino.
+     */
+    public static PersonDTO aPersonWithNino(String nino) {
+        return buildDefaultPerson().nino(nino).build();
     }
 
     private static PersonDTO.PersonDTOBuilder buildDefaultPerson() {

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/service/BenefitsServiceTest.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/service/BenefitsServiceTest.java
@@ -1,6 +1,8 @@
 package uk.gov.dhsc.htbhf.smartstub.service;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import uk.gov.dhsc.htbhf.smartstub.model.BenefitDTO;
 import uk.gov.dhsc.htbhf.smartstub.model.PersonDTO;
 
@@ -17,69 +19,68 @@ class BenefitsServiceTest {
 
     private BenefitsService benefitsService = new BenefitsService(new IdentifierService());
 
-    @Test
-    void shouldReturnIneligibleForMatchingNino() {
-        PersonDTO person = aPersonWhoIsDWPIneligible();
-
-        BenefitDTO benefit = benefitsService.getDWPBenefits(person.getNino());
-
-        assertThat(benefit.getEligibilityStatus()).isEqualTo(INELIGIBLE);
-    }
-
-    @Test
-    void shouldReturnIneligibleForAlternateMatchingNino() {
-        PersonDTO person = anAlternatePersonWhoIsDWPIneligible();
-
-        BenefitDTO benefit = benefitsService.getDWPBenefits(person.getNino());
-
-        assertThat(benefit.getEligibilityStatus()).isEqualTo(INELIGIBLE);
-    }
-
-    @Test
-    void shouldReturnEligibleForMatchingNino() {
-        PersonDTO person = aPersonWhoIsDWPEligible();
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "EA123456C",
+            "IE123456C",
+            "PE123456C",
+            "EE123456C",
+            "XE123456C"
+    })
+    void shouldReturnEligibleForMatchingNino(String nino) {
+        PersonDTO person = aPersonWithNino(nino);
 
         BenefitDTO benefit = benefitsService.getDWPBenefits(person.getNino());
 
         assertThat(benefit.getEligibilityStatus()).isEqualTo(ELIGIBLE);
     }
 
-    @Test
-    void shouldReturnEligibleForAlternateMatchingNino() {
-        PersonDTO person = anAlternatePersonWhoIsDWPEligible();
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "IA123456C",
+            "XI123456C",
+            "PI123456C",
+            "II123456C",
+            "XI123456C"
+    })
+    void shouldReturnInEligibleForMatchingNino(String nino) {
+        PersonDTO person = aPersonWithNino(nino);
 
         BenefitDTO benefit = benefitsService.getDWPBenefits(person.getNino());
 
-        assertThat(benefit.getEligibilityStatus()).isEqualTo(ELIGIBLE);
+        assertThat(benefit.getEligibilityStatus()).isEqualTo(INELIGIBLE);
     }
 
-    @Test
-    void shouldReturnPendingForMatchingNino() {
-        PersonDTO person = aPersonWhoIsDWPPending();
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "PA123456C",
+            "XP123456C",
+            "VP123456C",
+            "PP123456C",
+            "XP123456C"
+    })
+    void shouldReturnPendingForMatchingNino(String nino) {
+        PersonDTO person = aPersonWithNino(nino);
 
         BenefitDTO benefit = benefitsService.getDWPBenefits(person.getNino());
 
         assertThat(benefit.getEligibilityStatus()).isEqualTo(PENDING);
     }
 
-    @Test
-    void shouldReturnPendingForAlternateMatchingNino() {
-        PersonDTO person = anAlternatePersonWhoIsDWPPending();
-
-        BenefitDTO benefit = benefitsService.getDWPBenefits(person.getNino());
-
-        assertThat(benefit.getEligibilityStatus()).isEqualTo(PENDING);
-    }
-
-    @Test
-    void shouldReturnNoMatchNino() {
-        PersonDTO person = aPersonNotFound();
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "BA123456C",
+            "XW123456C",
+            "VN123456C",
+            "OK123456C",
+            "XL123456C"
+    })
+    void shouldReturnNoMatchForMatchingNino(String nino) {
+        PersonDTO person = aPersonWithNino(nino);
 
         BenefitDTO benefit = benefitsService.getDWPBenefits(person.getNino());
 
         assertThat(benefit.getEligibilityStatus()).isEqualTo(NO_MATCH);
-        assertThat(benefit.getNumberOfChildrenUnderOne()).isNull();
-        assertThat(benefit.getNumberOfChildrenUnderFour()).isNull();
     }
 
     @Test


### PR DESCRIPTION
Fixed matching rules so that the status is ELIGIBLE if either of the first two characters are ELIGIBLE, same for ineligible and pending.
ELIGIBLE takes precedence over INELIGIBLE, which takes precedence over PENDING. Everything else defaults to NO_MATCH.