### PR TITLE
HTBHF-2472 Add basic controller that does nothing apart from accept the…

### DIFF
--- a/src/main/java/uk/gov/dhsc/htbhf/smartstub/controller/v2/DWPBenefitControllerV2.java
+++ b/src/main/java/uk/gov/dhsc/htbhf/smartstub/controller/v2/DWPBenefitControllerV2.java
@@ -1,0 +1,25 @@
+package uk.gov.dhsc.htbhf.smartstub.controller.v2;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.dhsc.htbhf.smartstub.model.v2.IdentityAndEligibilityResponse;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/v2/dwp/benefits")
+@Slf4j
+@AllArgsConstructor
+public class DWPBenefitControllerV2 {
+
+    @GetMapping
+    public IdentityAndEligibilityResponse determineEligibility(@RequestHeader Map<String, String> headers) {
+        log.debug("Received DWP eligibility request, headers: {}", headers);
+        return IdentityAndEligibilityResponse.builder().build();
+    }
+
+}

--- a/src/main/java/uk/gov/dhsc/htbhf/smartstub/model/v2/DeathVerificationFlag.java
+++ b/src/main/java/uk/gov/dhsc/htbhf/smartstub/model/v2/DeathVerificationFlag.java
@@ -1,0 +1,17 @@
+package uk.gov.dhsc.htbhf.smartstub.model.v2;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum DeathVerificationFlag {
+
+    N_A("n/a"),
+    DEATH_NOT_VERIFIED("death_not_verified"),
+    LIMITED_SUPPORTING_DOCUMENTATION("limited_supporting_documentation"),
+    PARTIAL_SUPPORTING_DOCUMENTATION("partial_supporting_documentation"),
+    FULL_SUPPORTING_DOCUMENTATION("full_supporting_documentation");
+
+    private String responseValue;
+}

--- a/src/main/java/uk/gov/dhsc/htbhf/smartstub/model/v2/EligibilityOutcome.java
+++ b/src/main/java/uk/gov/dhsc/htbhf/smartstub/model/v2/EligibilityOutcome.java
@@ -1,0 +1,14 @@
+package uk.gov.dhsc.htbhf.smartstub.model.v2;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum EligibilityOutcome {
+    CONFIRMED,
+    NOT_CONFIRMED,
+    NOT_SET;
+
+    @JsonValue
+    public String getResponseValue() {
+        return this.name().toLowerCase();
+    }
+}

--- a/src/main/java/uk/gov/dhsc/htbhf/smartstub/model/v2/IdentityAndEligibilityResponse.java
+++ b/src/main/java/uk/gov/dhsc/htbhf/smartstub/model/v2/IdentityAndEligibilityResponse.java
@@ -1,0 +1,49 @@
+package uk.gov.dhsc.htbhf.smartstub.model.v2;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor(onConstructor_ = {@JsonCreator})
+public class IdentityAndEligibilityResponse {
+
+    @JsonProperty("identityStatus")
+    private IdentityOutcome identityStatus;
+
+    @JsonProperty("eligibilityStatus")
+    private final EligibilityOutcome eligibilityStatus;
+
+    @JsonProperty("deathVerificationFlag")
+    private final DeathVerificationFlag deathVerificationFlag;
+
+    @JsonProperty("mobilePhoneMatch")
+    private final VerificationOutcome mobilePhoneMatch;
+
+    @JsonProperty("emailAddressMatch")
+    private final VerificationOutcome emailAddressMatch;
+
+    @JsonProperty("addressLine1Match")
+    private final VerificationOutcome addressLine1Match;
+
+    @JsonProperty("postcodeMatch")
+    private final VerificationOutcome postcodeMatch;
+
+    @JsonProperty("pregnantChildDOBMatch")
+    private final VerificationOutcome pregnantChildDOBMatch;
+
+    @JsonProperty("qualifyingBenefits")
+    private final QualifyingBenefits qualifyingBenefits;
+
+    @JsonProperty("householdIdentifier")
+    private final String householdIdentifier;
+
+    @JsonProperty("dobOfChildrenUnder4")
+    private final List<LocalDate> dobOfChildrenUnder4;
+}

--- a/src/main/java/uk/gov/dhsc/htbhf/smartstub/model/v2/IdentityOutcome.java
+++ b/src/main/java/uk/gov/dhsc/htbhf/smartstub/model/v2/IdentityOutcome.java
@@ -1,0 +1,13 @@
+package uk.gov.dhsc.htbhf.smartstub.model.v2;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum IdentityOutcome {
+    MATCHED,
+    NOT_MATCHED;
+
+    @JsonValue
+    public String getResponseValue() {
+        return this.name().toLowerCase();
+    }
+}

--- a/src/main/java/uk/gov/dhsc/htbhf/smartstub/model/v2/QualifyingBenefits.java
+++ b/src/main/java/uk/gov/dhsc/htbhf/smartstub/model/v2/QualifyingBenefits.java
@@ -1,0 +1,17 @@
+package uk.gov.dhsc.htbhf.smartstub.model.v2;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum QualifyingBenefits {
+    UNIVERSAL_CREDIT,
+    EMPLOYMENT_AND_SUPPORT_ALLOWANCE,
+    INCOME_SUPPORT,
+    JOBSEEKERS_ALLOWANCE,
+    PENSION_CREDIT,
+    NOT_SET;
+
+    @JsonValue
+    public String getResponseValue() {
+        return this.name().toLowerCase();
+    }
+}

--- a/src/main/java/uk/gov/dhsc/htbhf/smartstub/model/v2/VerificationOutcome.java
+++ b/src/main/java/uk/gov/dhsc/htbhf/smartstub/model/v2/VerificationOutcome.java
@@ -1,0 +1,17 @@
+package uk.gov.dhsc.htbhf.smartstub.model.v2;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum VerificationOutcome {
+    MATCHED,
+    NOT_MATCHED,
+    NOT_HELD,
+    NOT_SUPPLIED,
+    INVALID_FORMAT,
+    NOT_SET;
+
+    @JsonValue
+    public String getResponseValue() {
+        return this.name().toLowerCase();
+    }
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/controller/v2/DWPBenefitControllerV2Test.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/controller/v2/DWPBenefitControllerV2Test.java
@@ -1,0 +1,44 @@
+package uk.gov.dhsc.htbhf.smartstub.controller.v2;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.dhsc.htbhf.smartstub.model.v2.IdentityAndEligibilityResponse;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.dhsc.htbhf.smartstub.helper.v2.HttpRequestTestDataFactory.aValidEligibilityHttpEntity;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class DWPBenefitControllerV2Test {
+
+    private static final URI ENDPOINT = URI.create("/v2/dwp/benefits");
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    void shouldReturnResponse() {
+        //Given
+        HttpEntity request = aValidEligibilityHttpEntity();
+
+        //When
+        ResponseEntity<IdentityAndEligibilityResponse> responseEntity = restTemplate.exchange(ENDPOINT,
+                HttpMethod.GET, request, IdentityAndEligibilityResponse.class);
+
+        //Then
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        IdentityAndEligibilityResponse expectedResponse = IdentityAndEligibilityResponse.builder().build();
+        assertThat(responseEntity.getBody()).isEqualTo(expectedResponse);
+    }
+
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/helper/v1/TestConstants.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/helper/v1/TestConstants.java
@@ -6,9 +6,11 @@ public final class TestConstants {
 
     public static final String HOMER_FIRST_NAME = "Homer";
     public static final String SIMPSON_LAST_NAME = "Simpson";
-    public static final LocalDate HOMER_DATE_OF_BIRTH = LocalDate.parse("1985-12-31");
+    public static final String HOMER_DATE_OF_BIRTH_STRING = "1985-12-31";
+    public static final LocalDate HOMER_DATE_OF_BIRTH = LocalDate.parse(HOMER_DATE_OF_BIRTH_STRING);
     public static final String HOMER_EMAIL = "homer@simpson.com";
     public static final String HOMER_MOBILE = "07700900000";
+    public static final String NINO = "EE123456C";
 
     public static final String SIMPSONS_ADDRESS_LINE_1 = "742 Evergreen Terrace";
     public static final String SIMPSONS_ADDRESS_LINE_2 = "Mystery Spot";

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/helper/v2/HttpRequestTestDataFactory.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/helper/v2/HttpRequestTestDataFactory.java
@@ -1,0 +1,25 @@
+package uk.gov.dhsc.htbhf.smartstub.helper.v2;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import static uk.gov.dhsc.htbhf.smartstub.helper.v1.TestConstants.HOMER_DATE_OF_BIRTH_STRING;
+import static uk.gov.dhsc.htbhf.smartstub.helper.v1.TestConstants.NINO;
+import static uk.gov.dhsc.htbhf.smartstub.helper.v1.TestConstants.SIMPSON_LAST_NAME;
+
+public class HttpRequestTestDataFactory {
+
+    public static HttpEntity<Void> aValidEligibilityHttpEntity() {
+        LocalDate eligibilityEndDate = LocalDate.now().plusDays(28);
+        String eligibilityEndDateString = DateTimeFormatter.ISO_LOCAL_DATE.format(eligibilityEndDate);
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.add("surname", SIMPSON_LAST_NAME);
+        httpHeaders.add("nino", NINO);
+        httpHeaders.add("dateOfBirth", HOMER_DATE_OF_BIRTH_STRING);
+        httpHeaders.add("eligibilityEndDate", eligibilityEndDateString);
+        return new HttpEntity<>(httpHeaders);
+    }
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/model/v2/DeathVerificationFlagTest.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/model/v2/DeathVerificationFlagTest.java
@@ -1,0 +1,22 @@
+package uk.gov.dhsc.htbhf.smartstub.model.v2;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DeathVerificationFlagTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "N_A, n/a",
+            "DEATH_NOT_VERIFIED, death_not_verified",
+            "LIMITED_SUPPORTING_DOCUMENTATION, limited_supporting_documentation",
+            "PARTIAL_SUPPORTING_DOCUMENTATION, partial_supporting_documentation",
+            "FULL_SUPPORTING_DOCUMENTATION, full_supporting_documentation"
+    })
+    void shouldGetResponseValue(DeathVerificationFlag deathVerificationFlag, String expectedResponseValue) {
+        assertThat(deathVerificationFlag.getResponseValue()).isEqualTo(expectedResponseValue);
+    }
+
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/model/v2/EligibilityOutcomeTest.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/model/v2/EligibilityOutcomeTest.java
@@ -1,0 +1,20 @@
+package uk.gov.dhsc.htbhf.smartstub.model.v2;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EligibilityOutcomeTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "CONFIRMED, confirmed",
+            "NOT_CONFIRMED, not_confirmed",
+            "NOT_SET, not_set"
+    })
+    void shouldGetResponseValue(EligibilityOutcome eligibilityOutcome, String expectedResponseValue) {
+        assertThat(eligibilityOutcome.getResponseValue()).isEqualTo(expectedResponseValue);
+    }
+
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/model/v2/IdentityOutcomeTest.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/model/v2/IdentityOutcomeTest.java
@@ -1,0 +1,19 @@
+package uk.gov.dhsc.htbhf.smartstub.model.v2;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IdentityOutcomeTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "MATCHED, matched",
+            "NOT_MATCHED, not_matched"
+    })
+    void shouldGetResponseValue(IdentityOutcome identityOutcome, String expectedResponseValue) {
+        assertThat(identityOutcome.getResponseValue()).isEqualTo(expectedResponseValue);
+    }
+
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/model/v2/QualifyingBenefitsTest.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/model/v2/QualifyingBenefitsTest.java
@@ -1,0 +1,23 @@
+package uk.gov.dhsc.htbhf.smartstub.model.v2;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QualifyingBenefitsTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "UNIVERSAL_CREDIT, universal_credit",
+            "EMPLOYMENT_AND_SUPPORT_ALLOWANCE, employment_and_support_allowance",
+            "INCOME_SUPPORT, income_support",
+            "JOBSEEKERS_ALLOWANCE, jobseekers_allowance",
+            "PENSION_CREDIT, pension_credit",
+            "NOT_SET, not_set"
+    })
+    void shouldGetResponseValue(QualifyingBenefits qualifyingBenefits, String expectedResponseValue) {
+        assertThat(qualifyingBenefits.getResponseValue()).isEqualTo(expectedResponseValue);
+    }
+
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/model/v2/VerificationOutcomeTest.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/model/v2/VerificationOutcomeTest.java
@@ -1,0 +1,23 @@
+package uk.gov.dhsc.htbhf.smartstub.model.v2;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VerificationOutcomeTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "MATCHED, matched",
+            "NOT_MATCHED, not_matched",
+            "NOT_HELD, not_held",
+            "NOT_SUPPLIED, not_supplied",
+            "INVALID_FORMAT, invalid_format",
+            "NOT_SET, not_set"
+    })
+    void shouldGetResponseValue(VerificationOutcome verificationOutcome, String expectedResponseValue) {
+        assertThat(verificationOutcome.getResponseValue()).isEqualTo(expectedResponseValue);
+    }
+
+}


### PR DESCRIPTION
…request and return an empty response.

Add a very simple controller for the V2 endpoint that receives a GET request and logs out the headers received, the response is the correct response object according to the DWP swagger spec, but currently returns an empty response.