### PR TITLE
HTBHF-2472 Add validation to DWP controller and unit test all objects and controller.

### DIFF
--- a/src/main/java/uk/gov/dhsc/htbhf/smartstub/controller/v2/DWPBenefitControllerV2.java
+++ b/src/main/java/uk/gov/dhsc/htbhf/smartstub/controller/v2/DWPBenefitControllerV2.java
@@ -14,6 +14,17 @@ import uk.gov.dhsc.htbhf.smartstub.model.v2.IdentityAndEligibilityResponse;
 @AllArgsConstructor
 public class DWPBenefitControllerV2 {
 
+    /**
+     * Determines the eligibility of the claimant from the given request details. The request
+     * object is built from header values in the request using {@link DwpEligibilityRequestResolver}.
+     * The request object is validated, but due to having to use the argument resolver, this
+     * is done manually in {@link DwpEligibilityRequestResolver} rather than using Spring's @Valid
+     * annotation because this doesn't work on request parameters which are built using
+     * an argument resolver.
+     *
+     * @param request The valid request object built up by {@link DwpEligibilityRequestResolver}
+     * @return The identity and eligibility response.
+     */
     @GetMapping
     public IdentityAndEligibilityResponse determineEligibility(DWPEligibilityRequestV2 request) {
         log.debug("Received DWP eligibility request: {}", request);

--- a/src/main/java/uk/gov/dhsc/htbhf/smartstub/controller/v2/DwpEligibilityRequestResolver.java
+++ b/src/main/java/uk/gov/dhsc/htbhf/smartstub/controller/v2/DwpEligibilityRequestResolver.java
@@ -2,6 +2,9 @@ package uk.gov.dhsc.htbhf.smartstub.controller.v2;
 
 import lombok.AllArgsConstructor;
 import org.springframework.core.MethodParameter;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -21,7 +24,19 @@ public class DwpEligibilityRequestResolver implements HandlerMethodArgumentResol
 
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
-                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
-        return converter.convert(webRequest);
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        DWPEligibilityRequestV2 request = converter.convert(webRequest);
+        validateRequest(parameter, webRequest, binderFactory, request);
+        return request;
+    }
+
+    private void validateRequest(MethodParameter parameter, NativeWebRequest webRequest, WebDataBinderFactory binderFactory,
+                                 DWPEligibilityRequestV2 request) throws Exception {
+        WebDataBinder binder = binderFactory.createBinder(webRequest, request, "request");
+        binder.validate();
+        BindingResult bindingResult = binder.getBindingResult();
+        if (bindingResult.getErrorCount() > 0) {
+            throw new MethodArgumentNotValidException(parameter, bindingResult);
+        }
     }
 }

--- a/src/main/java/uk/gov/dhsc/htbhf/smartstub/converter/v2/RequestHeaderToDWPEligibilityRequestV2Converter.java
+++ b/src/main/java/uk/gov/dhsc/htbhf/smartstub/converter/v2/RequestHeaderToDWPEligibilityRequestV2Converter.java
@@ -15,7 +15,7 @@ public class RequestHeaderToDWPEligibilityRequestV2Converter {
     public DWPEligibilityRequestV2 convert(NativeWebRequest webRequest) {
         return DWPEligibilityRequestV2.builder()
                 .person(buildPerson(webRequest))
-                .eligibleEndDate(nullSafeGetDate(webRequest, "eligibleEndDate"))
+                .eligibilityEndDate(nullSafeGetDate(webRequest, "eligibilityEndDate"))
                 .ucMonthlyIncomeThresholdInPence(nullSafeGetInteger(webRequest, "ucMonthlyIncomeThreshold"))
                 .build();
     }

--- a/src/main/java/uk/gov/dhsc/htbhf/smartstub/model/v2/DWPEligibilityRequestV2.java
+++ b/src/main/java/uk/gov/dhsc/htbhf/smartstub/model/v2/DWPEligibilityRequestV2.java
@@ -6,7 +6,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -21,11 +20,10 @@ public class DWPEligibilityRequestV2 {
     @JsonProperty("person")
     private PersonDTOV2 person;
 
-    @NotNull
     @JsonProperty("ucMonthlyIncomeThreshold")
     private final Integer ucMonthlyIncomeThresholdInPence;
 
     @NotNull
-    @JsonProperty("eligibleEndDate")
-    private final LocalDate eligibleEndDate;
+    @JsonProperty("eligibilityEndDate")
+    private final LocalDate eligibilityEndDate;
 }

--- a/src/main/java/uk/gov/dhsc/htbhf/smartstub/model/v2/PersonDTOV2.java
+++ b/src/main/java/uk/gov/dhsc/htbhf/smartstub/model/v2/PersonDTOV2.java
@@ -21,7 +21,7 @@ public class PersonDTOV2 {
     private final String surname;
 
     @NotNull
-    @Pattern(regexp = "[a-zA-Z]{2}\\d{6}[a-dA-D]")
+    @Pattern(regexp = "^(?!BG|GB|NK|KN|TN|NT|ZZ)[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z](\\d{6})[A-D]$")
     @JsonProperty("nino")
     private final String nino;
 
@@ -35,14 +35,18 @@ public class PersonDTOV2 {
     private final String addressLine1;
 
     @JsonProperty("postcode")
+    @Pattern(regexp = "^(GIR ?0AA|[A-PR-UWYZ]([0-9]{1,2}|([A-HK-Y][0-9]([0-9ABEHMNPRV-Y])?)|[0-9][A-HJKPS-UW]) ?[0-9][ABD-HJLNP-UW-Z]{2})$")
     private final String postcode;
 
     @JsonProperty("emailAddress")
+    @Pattern(regexp = "(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$)")
     private final String emailAddress;
 
     @JsonProperty("mobilePhoneNumber")
+    @Pattern(regexp = "^\\+44\\d{9,10}$")
     private final String mobilePhoneNumber;
 
+    @Past
     @JsonProperty("pregnantDependentDob")
     private LocalDate pregnantDependentDob;
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/controller/v2/DWPBenefitControllerV2Test.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/controller/v2/DWPBenefitControllerV2Test.java
@@ -10,12 +10,15 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.dhsc.htbhf.errorhandler.ErrorResponse;
 import uk.gov.dhsc.htbhf.smartstub.model.v2.IdentityAndEligibilityResponse;
 
 import java.net.URI;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.dhsc.htbhf.assertions.IntegrationTestAssertions.assertValidationErrorInResponse;
 import static uk.gov.dhsc.htbhf.smartstub.helper.v2.HttpRequestTestDataFactory.aValidEligibilityHttpEntity;
+import static uk.gov.dhsc.htbhf.smartstub.helper.v2.HttpRequestTestDataFactory.anInvalidEligibilityHttpEntity;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -27,7 +30,7 @@ class DWPBenefitControllerV2Test {
     private TestRestTemplate restTemplate;
 
     @Test
-    void shouldReturnResponse() {
+    void shouldReturnOkResponse() {
         //Given
         HttpEntity request = aValidEligibilityHttpEntity();
 
@@ -39,6 +42,20 @@ class DWPBenefitControllerV2Test {
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
         IdentityAndEligibilityResponse expectedResponse = IdentityAndEligibilityResponse.builder().build();
         assertThat(responseEntity.getBody()).isEqualTo(expectedResponse);
+    }
+
+    @Test
+    void shouldReturnBadRequestResponseWithInvalidRequest() {
+        //Given
+        HttpEntity request = anInvalidEligibilityHttpEntity();
+
+        //When
+        ResponseEntity<ErrorResponse> responseEntity = restTemplate.exchange(ENDPOINT, HttpMethod.GET, request, ErrorResponse.class);
+
+        //Then
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertValidationErrorInResponse(responseEntity, "person.nino",
+                "must match \"^(?!BG|GB|NK|KN|TN|NT|ZZ)[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z](\\d{6})[A-D]$\"");
     }
 
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/converter/v2/RequestHeaderToDWPEligibilityRequestV2ConverterTest.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/converter/v2/RequestHeaderToDWPEligibilityRequestV2ConverterTest.java
@@ -28,7 +28,7 @@ class RequestHeaderToDWPEligibilityRequestV2ConverterTest {
         //Given
         LocalDate eligibilityDate = LocalDate.now().plusDays(28);
         String eligibilityDateString = eligibilityDate.format(DateTimeFormatter.ISO_LOCAL_DATE);
-        lenient().when(nativeWebRequest.getHeader("eligibleEndDate")).thenReturn(eligibilityDateString);
+        lenient().when(nativeWebRequest.getHeader("eligibilityEndDate")).thenReturn(eligibilityDateString);
         lenient().when(nativeWebRequest.getHeader("ucMonthlyIncomeThreshold")).thenReturn(String.valueOf(TestConstants.UC_MONTHLY_INCOME_THRESHOLD));
         lenient().when(nativeWebRequest.getHeader("surname")).thenReturn(TestConstants.SIMPSON_LAST_NAME);
         lenient().when(nativeWebRequest.getHeader("nino")).thenReturn(TestConstants.NINO);

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/helper/TestConstants.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/helper/TestConstants.java
@@ -9,7 +9,7 @@ public final class TestConstants {
     public static final String HOMER_DATE_OF_BIRTH_STRING = "1985-12-31";
     public static final LocalDate HOMER_DATE_OF_BIRTH = LocalDate.parse(HOMER_DATE_OF_BIRTH_STRING);
     public static final String HOMER_EMAIL = "homer@simpson.com";
-    public static final String HOMER_MOBILE = "07700900000";
+    public static final String HOMER_MOBILE = "+447700900000";
     public static final String NINO = "EE123456C";
     public static final String MAGGIE_DATE_OF_BIRTH_STRING = "1985-12-31";
     public static final LocalDate MAGGIE_DATE_OF_BIRTH = LocalDate.parse("1985-12-31");

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/helper/v2/DWPEligibilityRequestV2TestDataFactory.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/helper/v2/DWPEligibilityRequestV2TestDataFactory.java
@@ -1,6 +1,7 @@
 package uk.gov.dhsc.htbhf.smartstub.helper.v2;
 
 import uk.gov.dhsc.htbhf.smartstub.model.v2.DWPEligibilityRequestV2;
+import uk.gov.dhsc.htbhf.smartstub.model.v2.PersonDTOV2;
 
 import java.time.LocalDate;
 
@@ -10,11 +11,27 @@ import static uk.gov.dhsc.htbhf.smartstub.helper.v2.PersonDTOV2TestDataFactory.a
 public class DWPEligibilityRequestV2TestDataFactory {
 
     public static DWPEligibilityRequestV2 aValidDWPEligibilityRequestV2() {
+        return validDWPEligibilityRequestBuilder()
+                .build();
+    }
+
+    public static DWPEligibilityRequestV2 aValidDWPEligibilityRequestV2WithPerson(PersonDTOV2 person) {
+        return validDWPEligibilityRequestBuilder()
+                .person(person)
+                .build();
+    }
+
+    public static DWPEligibilityRequestV2 aValidDWPEligibilityRequestV2WithEligibilityEndDate(LocalDate eligibilityEndDate) {
+        return validDWPEligibilityRequestBuilder()
+                .eligibilityEndDate(eligibilityEndDate)
+                .build();
+    }
+
+    private static DWPEligibilityRequestV2.DWPEligibilityRequestV2Builder validDWPEligibilityRequestBuilder() {
         return DWPEligibilityRequestV2.builder()
                 .person(aValidPersonDTOV2())
-                .eligibleEndDate(LocalDate.now().plusDays(28))
-                .ucMonthlyIncomeThresholdInPence(UC_MONTHLY_INCOME_THRESHOLD)
-                .build();
+                .eligibilityEndDate(LocalDate.now().plusDays(28))
+                .ucMonthlyIncomeThresholdInPence(UC_MONTHLY_INCOME_THRESHOLD);
     }
 
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/helper/v2/HttpRequestTestDataFactory.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/helper/v2/HttpRequestTestDataFactory.java
@@ -11,13 +11,21 @@ import static uk.gov.dhsc.htbhf.smartstub.helper.TestConstants.*;
 public class HttpRequestTestDataFactory {
 
     public static HttpEntity<Void> aValidEligibilityHttpEntity() {
+        return buildHttpEntityWithNino(NINO);
+    }
+
+    public static HttpEntity<Void> anInvalidEligibilityHttpEntity() {
+        return buildHttpEntityWithNino("ZZZZZZZZZ");
+    }
+
+    private static HttpEntity<Void> buildHttpEntityWithNino(String nino) {
         LocalDate eligibilityEndDate = LocalDate.now().plusDays(28);
         String eligibilityEndDateString = DateTimeFormatter.ISO_LOCAL_DATE.format(eligibilityEndDate);
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.add("surname", SIMPSON_LAST_NAME);
-        httpHeaders.add("nino", NINO);
+        httpHeaders.add("nino", nino);
         httpHeaders.add("dateOfBirth", HOMER_DATE_OF_BIRTH_STRING);
-        httpHeaders.add("eligibleEndDate", eligibilityEndDateString);
+        httpHeaders.add("eligibilityEndDate", eligibilityEndDateString);
         httpHeaders.add("addressLine1", SIMPSONS_ADDRESS_LINE_1);
         httpHeaders.add("postcode", SIMPSONS_POSTCODE);
         httpHeaders.add("emailAddress", HOMER_EMAIL);

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/helper/v2/PersonDTOV2TestDataFactory.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/helper/v2/PersonDTOV2TestDataFactory.java
@@ -2,11 +2,58 @@ package uk.gov.dhsc.htbhf.smartstub.helper.v2;
 
 import uk.gov.dhsc.htbhf.smartstub.model.v2.PersonDTOV2;
 
+import java.time.LocalDate;
+
 import static uk.gov.dhsc.htbhf.smartstub.helper.TestConstants.*;
 
 public class PersonDTOV2TestDataFactory {
 
     public static PersonDTOV2 aValidPersonDTOV2() {
+        return validPersonBuilder().build();
+    }
+
+    public static PersonDTOV2 aPersonDTOV2WithSurname(String surname) {
+        return validPersonBuilder().surname(surname).build();
+    }
+
+    public static PersonDTOV2 aPersonDTOV2WithNino(String nino) {
+        return validPersonBuilder().nino(nino).build();
+    }
+
+    public static PersonDTOV2 aPersonDTOV2WithPostcode(String postcode) {
+        return validPersonBuilder().postcode(postcode).build();
+    }
+
+    public static PersonDTOV2 aPersonDTOV2WithEmailAddress(String emailAddress) {
+        return validPersonBuilder().emailAddress(emailAddress).build();
+    }
+
+    public static PersonDTOV2 aPersonDTOV2WithMobilePhoneNumber(String mobilePhoneNumber) {
+        return validPersonBuilder().mobilePhoneNumber(mobilePhoneNumber).build();
+    }
+
+    public static PersonDTOV2 aPersonDTOV2WithDateOfBirth(LocalDate dateOfBirth) {
+        return validPersonBuilder().dateOfBirth(dateOfBirth).build();
+    }
+
+    public static PersonDTOV2 aPersonDTOV2WithPregnantDependantDob(LocalDate dateOfBirth) {
+        return validPersonBuilder().pregnantDependentDob(dateOfBirth).build();
+    }
+
+    public static PersonDTOV2 aPersonDTOV2WithAddressLine1(String addressLine1) {
+        return validPersonBuilder().addressLine1(addressLine1).build();
+    }
+
+    public static PersonDTOV2 aValidPersonDTOV2WithMandatoryFieldsOnly() {
+        return PersonDTOV2.builder()
+                .nino(NINO)
+                .surname(SIMPSON_LAST_NAME)
+                .addressLine1(SIMPSONS_ADDRESS_LINE_1)
+                .dateOfBirth(HOMER_DATE_OF_BIRTH)
+                .build();
+    }
+
+    private static PersonDTOV2.PersonDTOV2Builder validPersonBuilder() {
         return PersonDTOV2.builder()
                 .nino(NINO)
                 .surname(SIMPSON_LAST_NAME)
@@ -15,7 +62,6 @@ public class PersonDTOV2TestDataFactory {
                 .emailAddress(HOMER_EMAIL)
                 .mobilePhoneNumber(HOMER_MOBILE)
                 .dateOfBirth(HOMER_DATE_OF_BIRTH)
-                .pregnantDependentDob(MAGGIE_DATE_OF_BIRTH)
-                .build();
+                .pregnantDependentDob(MAGGIE_DATE_OF_BIRTH);
     }
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/model/v2/DWPEligibilityRequestV2Test.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/model/v2/DWPEligibilityRequestV2Test.java
@@ -1,0 +1,46 @@
+package uk.gov.dhsc.htbhf.smartstub.model.v2;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.dhsc.htbhf.assertions.AbstractValidationTest;
+
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+
+import static uk.gov.dhsc.htbhf.assertions.ConstraintViolationAssert.assertThat;
+import static uk.gov.dhsc.htbhf.smartstub.helper.v2.DWPEligibilityRequestV2TestDataFactory.aValidDWPEligibilityRequestV2;
+import static uk.gov.dhsc.htbhf.smartstub.helper.v2.DWPEligibilityRequestV2TestDataFactory.aValidDWPEligibilityRequestV2WithEligibilityEndDate;
+import static uk.gov.dhsc.htbhf.smartstub.helper.v2.DWPEligibilityRequestV2TestDataFactory.aValidDWPEligibilityRequestV2WithPerson;
+import static uk.gov.dhsc.htbhf.smartstub.helper.v2.PersonDTOV2TestDataFactory.aPersonDTOV2WithSurname;
+
+class DWPEligibilityRequestV2Test extends AbstractValidationTest {
+
+    @Test
+    void shouldSuccessfullyValidateRequest() {
+        DWPEligibilityRequestV2 request = aValidDWPEligibilityRequestV2();
+        Set<ConstraintViolation<DWPEligibilityRequestV2>> violations = validator.validate(request);
+        assertThat(violations).hasNoViolations();
+    }
+
+    @Test
+    void shouldFailValidationWithNoPerson() {
+        DWPEligibilityRequestV2 request = aValidDWPEligibilityRequestV2WithPerson(null);
+        Set<ConstraintViolation<DWPEligibilityRequestV2>> violations = validator.validate(request);
+        assertThat(violations).hasSingleConstraintViolation("must not be null", "person");
+    }
+
+    @Test
+    void shouldFailValidationWithInvalidPerson() {
+        PersonDTOV2 person = aPersonDTOV2WithSurname(null);
+        DWPEligibilityRequestV2 request = aValidDWPEligibilityRequestV2WithPerson(person);
+        Set<ConstraintViolation<DWPEligibilityRequestV2>> violations = validator.validate(request);
+        assertThat(violations).hasSingleConstraintViolation("must not be null", "person.surname");
+    }
+
+    @Test
+    void shouldFailValidationWithInvalidEligibilityEndDate() {
+        DWPEligibilityRequestV2 request = aValidDWPEligibilityRequestV2WithEligibilityEndDate(null);
+        Set<ConstraintViolation<DWPEligibilityRequestV2>> violations = validator.validate(request);
+        assertThat(violations).hasSingleConstraintViolation("must not be null", "eligibilityEndDate");
+    }
+
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/model/v2/PersonDTOV2Test.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/model/v2/PersonDTOV2Test.java
@@ -1,0 +1,132 @@
+package uk.gov.dhsc.htbhf.smartstub.model.v2;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import uk.gov.dhsc.htbhf.assertions.AbstractValidationTest;
+
+import java.time.LocalDate;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+
+import static uk.gov.dhsc.htbhf.assertions.ConstraintViolationAssert.assertThat;
+import static uk.gov.dhsc.htbhf.smartstub.helper.v2.PersonDTOV2TestDataFactory.*;
+
+class PersonDTOV2Test extends AbstractValidationTest {
+
+    @Test
+    void shouldSuccessfullyValidatePersonWithMandatoryFieldsOnly() {
+        PersonDTOV2 personDTOV2 = aValidPersonDTOV2WithMandatoryFieldsOnly();
+        Set<ConstraintViolation<PersonDTOV2>> violations = validator.validate(personDTOV2);
+        assertThat(violations).hasNoViolations();
+    }
+
+    @Test
+    void shouldSuccessfullyValidatePersonWithAllFields() {
+        PersonDTOV2 personDTOV2 = aValidPersonDTOV2();
+        Set<ConstraintViolation<PersonDTOV2>> violations = validator.validate(personDTOV2);
+        assertThat(violations).hasNoViolations();
+    }
+
+    @Test
+    void shouldFailValidationWithMissingSurname() {
+        PersonDTOV2 personDTOV2 = aPersonDTOV2WithSurname(null);
+        Set<ConstraintViolation<PersonDTOV2>> violations = validator.validate(personDTOV2);
+        assertThat(violations).hasSingleConstraintViolation("must not be null", "surname");
+    }
+
+    @Test
+    void shouldFailValidationWithMissingNino() {
+        PersonDTOV2 personDTOV2 = aPersonDTOV2WithNino(null);
+        Set<ConstraintViolation<PersonDTOV2>> violations = validator.validate(personDTOV2);
+        assertThat(violations).hasSingleConstraintViolation("must not be null", "nino");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "",
+            "YYHU456781",
+            "888888888",
+            "ABCDEFGHI",
+            "ZQQ123456CZ",
+            "QQ123456T"
+    })
+    void shouldFailValidationWithInvalidNino(String nino) {
+        PersonDTOV2 personDTOV2 = aPersonDTOV2WithNino(nino);
+        Set<ConstraintViolation<PersonDTOV2>> violations = validator.validate(personDTOV2);
+        assertThat(violations).hasSingleConstraintViolation(
+                "must match \"^(?!BG|GB|NK|KN|TN|NT|ZZ)[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z](\\d{6})[A-D]$\"", "nino");
+    }
+
+    @Test
+    void shouldFailValidationWithMissingDateOfBirth() {
+        PersonDTOV2 personDTOV2 = aPersonDTOV2WithDateOfBirth(null);
+        Set<ConstraintViolation<PersonDTOV2>> violations = validator.validate(personDTOV2);
+        assertThat(violations).hasSingleConstraintViolation("must not be null", "dateOfBirth");
+    }
+
+    @Test
+    void shouldFailValidationWithDateOfBirthInFuture() {
+        PersonDTOV2 personDTOV2 = aPersonDTOV2WithDateOfBirth(LocalDate.now().plusYears(1));
+        Set<ConstraintViolation<PersonDTOV2>> violations = validator.validate(personDTOV2);
+        assertThat(violations).hasSingleConstraintViolation("must be a past date", "dateOfBirth");
+    }
+
+    @Test
+    void shouldFailValidationWithMissingAddressLine1() {
+        PersonDTOV2 personDTOV2 = aPersonDTOV2WithAddressLine1(null);
+        Set<ConstraintViolation<PersonDTOV2>> violations = validator.validate(personDTOV2);
+        assertThat(violations).hasSingleConstraintViolation("must not be null", "addressLine1");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "",
+            "AA1122BB",
+            "A",
+            "11AA21",
+    })
+    void shouldFailValidationWithInvalidPostcode(String postcode) {
+        PersonDTOV2 personDTOV2 = aPersonDTOV2WithPostcode(postcode);
+        Set<ConstraintViolation<PersonDTOV2>> violations = validator.validate(personDTOV2);
+        assertThat(violations).hasSingleConstraintViolation(
+                "must match \"^(GIR ?0AA|[A-PR-UWYZ]([0-9]{1,2}|([A-HK-Y][0-9]([0-9ABEHMNPRV-Y])?)|[0-9][A-HJKPS-UW]) ?[0-9][ABD-HJLNP-UW-Z]{2})$\"",
+                "postcode");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "plainaddress",
+            "#@%^%#$@#$@#.com",
+            "@domain.com"
+    })
+    void shouldFailValidationWithInvalidEmailAddress(String emailAddress) {
+        PersonDTOV2 personDTOV2 = aPersonDTOV2WithEmailAddress(emailAddress);
+        Set<ConstraintViolation<PersonDTOV2>> violations = validator.validate(personDTOV2);
+        assertThat(violations).hasSingleConstraintViolation(
+                "must match \"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$)\"",
+                "emailAddress");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "plainaddress",
+            "#@%^%#$@#$@#.com",
+            "@domain.com"
+    })
+    void shouldFailValidationWithInvalidMobilePhoneNumber(String mobilePhoneNumber) {
+        PersonDTOV2 personDTOV2 = aPersonDTOV2WithMobilePhoneNumber(mobilePhoneNumber);
+        Set<ConstraintViolation<PersonDTOV2>> violations = validator.validate(personDTOV2);
+        assertThat(violations).hasSingleConstraintViolation(
+                "must match \"^\\+44\\d{9,10}$\"",
+                "mobilePhoneNumber");
+    }
+
+    @Test
+    void shouldFailValidationWithPregnantDependantDobInFuture() {
+        PersonDTOV2 personDTOV2 = aPersonDTOV2WithPregnantDependantDob(LocalDate.now().plusYears(1));
+        Set<ConstraintViolation<PersonDTOV2>> violations = validator.validate(personDTOV2);
+        assertThat(violations).hasSingleConstraintViolation("must be a past date", "pregnantDependentDob");
+    }
+
+}


### PR DESCRIPTION
Sadly to enable validation using the custom argument resolver we need to call validation with code and can't just rely on @Valid to work, but the code isn't excessive and the end result is the same.