### PR TITLE
HTBHF-2509 Add disabled unit tests for the IdentityAndEligibilityService.

### DIFF
--- a/src/main/java/uk/gov/dhsc/htbhf/smartstub/service/v2/IdentityAndEligibilityService.java
+++ b/src/main/java/uk/gov/dhsc/htbhf/smartstub/service/v2/IdentityAndEligibilityService.java
@@ -1,0 +1,11 @@
+package uk.gov.dhsc.htbhf.smartstub.service.v2;
+
+import uk.gov.dhsc.htbhf.smartstub.model.v2.DWPEligibilityRequestV2;
+import uk.gov.dhsc.htbhf.smartstub.model.v2.IdentityAndEligibilityResponse;
+
+public class IdentityAndEligibilityService {
+
+    public IdentityAndEligibilityResponse evaluateEligibility(DWPEligibilityRequestV2 request) {
+        return null;
+    }
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/helper/TestConstants.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/helper/TestConstants.java
@@ -1,6 +1,10 @@
 package uk.gov.dhsc.htbhf.smartstub.helper;
 
 import java.time.LocalDate;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 
 public final class TestConstants {
 
@@ -14,9 +18,24 @@ public final class TestConstants {
     public static final String MAGGIE_DATE_OF_BIRTH_STRING = "1985-12-31";
     public static final LocalDate MAGGIE_DATE_OF_BIRTH = LocalDate.parse("1985-12-31");
     public static final int UC_MONTHLY_INCOME_THRESHOLD = 40800;
+    public static final String HOUSEHOLD_IDENTIFIER = "household1";
 
     public static final String SIMPSONS_ADDRESS_LINE_1 = "742 Evergreen Terrace";
     public static final String SIMPSONS_ADDRESS_LINE_2 = "Mystery Spot";
     public static final String SIMPSONS_TOWN = "Springfield";
     public static final String SIMPSONS_POSTCODE = "AA1 1AA";
+
+    public static final String ADDRESS_LINE_ONE_NOT_MATCHED_SURNAME = "AddressLineOneNotMatched";
+    public static final String POSTCODE_NOT_MATCHED_SURNAME = "PostcodeNotMatched";
+    public static final String MOBILE_NOT_HELD_SURNAME = "MobileNotHeld";
+    public static final String EMAIL_NOT_HELD_SURNAME = "EmailNotHeld";
+    public static final String MOBILE_AND_EMAIL_NOT_HELD_SURNAME = "MobileAndEmailNotHeld";
+    public static final String MOBILE_NOT_MATCHED_SURNAME = "MobileNotMatched";
+    public static final String EMAIL_NOT_MATCHED_SURNAME = "EmailNotMatched";
+    public static final String MOBILE_AND_EMAIL_NOT_MATCHED_SURNAME = "MobileAndEmailNotMatched";
+
+    public static final LocalDate SIX_MONTH_OLD = LocalDate.now().minusMonths(6);
+    public static final LocalDate THREE_YEAR_OLD = LocalDate.now().minusYears(3);
+    public static final List<LocalDate> TWO_CHILDREN = asList(SIX_MONTH_OLD, THREE_YEAR_OLD);
+    public static final List<LocalDate> SINGLE_THREE_YEAR_OLD = singletonList(THREE_YEAR_OLD);
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/helper/v2/IdentityAndEligibilityResponseTestDataFactory.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/helper/v2/IdentityAndEligibilityResponseTestDataFactory.java
@@ -1,0 +1,95 @@
+package uk.gov.dhsc.htbhf.smartstub.helper.v2;
+
+import uk.gov.dhsc.htbhf.smartstub.model.v2.*;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+
+import static uk.gov.dhsc.htbhf.smartstub.helper.TestConstants.HOUSEHOLD_IDENTIFIER;
+
+public class IdentityAndEligibilityResponseTestDataFactory {
+
+    public static IdentityAndEligibilityResponse anIdentityMatchFailedResponse() {
+        return IdentityAndEligibilityResponse.builder()
+                .identityStatus(IdentityOutcome.NOT_MATCHED)
+                .eligibilityStatus(EligibilityOutcome.NOT_SET)
+                .qualifyingBenefits(QualifyingBenefits.NOT_SET)
+                .mobilePhoneMatch(VerificationOutcome.NOT_SET)
+                .emailAddressMatch(VerificationOutcome.NOT_SET)
+                .addressLine1Match(VerificationOutcome.NOT_SET)
+                .postcodeMatch(VerificationOutcome.NOT_SET)
+                .pregnantChildDOBMatch(VerificationOutcome.NOT_SET)
+                .householdIdentifier(null)
+                .dobOfChildrenUnder4(Collections.emptyList())
+                .deathVerificationFlag(DeathVerificationFlag.N_A)
+                .build();
+    }
+
+    public static IdentityAndEligibilityResponse anIdentityMatchedEligibilityNotConfirmedResponse() {
+        return IdentityAndEligibilityResponse.builder()
+                .identityStatus(IdentityOutcome.MATCHED)
+                .eligibilityStatus(EligibilityOutcome.NOT_CONFIRMED)
+                .qualifyingBenefits(QualifyingBenefits.NOT_SET)
+                .mobilePhoneMatch(VerificationOutcome.NOT_SET)
+                .emailAddressMatch(VerificationOutcome.NOT_SET)
+                .addressLine1Match(VerificationOutcome.NOT_SET)
+                .postcodeMatch(VerificationOutcome.NOT_SET)
+                .pregnantChildDOBMatch(VerificationOutcome.NOT_SET)
+                .householdIdentifier(null)
+                .dobOfChildrenUnder4(Collections.emptyList())
+                .deathVerificationFlag(DeathVerificationFlag.N_A)
+                .build();
+    }
+
+    public static IdentityAndEligibilityResponse anIdentityMatchedEligibilityConfirmedPostcodeNotMatchedResponse() {
+        return IdentityAndEligibilityResponse.builder()
+                .identityStatus(IdentityOutcome.MATCHED)
+                .eligibilityStatus(EligibilityOutcome.CONFIRMED)
+                .qualifyingBenefits(QualifyingBenefits.NOT_SET)
+                .mobilePhoneMatch(VerificationOutcome.NOT_SET)
+                .emailAddressMatch(VerificationOutcome.NOT_SET)
+                .addressLine1Match(VerificationOutcome.MATCHED)
+                .postcodeMatch(VerificationOutcome.NOT_MATCHED)
+                .pregnantChildDOBMatch(VerificationOutcome.NOT_SET)
+                .householdIdentifier(null)
+                .dobOfChildrenUnder4(Collections.emptyList())
+                .deathVerificationFlag(DeathVerificationFlag.N_A)
+                .build();
+    }
+
+    public static IdentityAndEligibilityResponse anIdentityMatchedEligibilityConfirmedAddressNotMatchedResponse() {
+        return IdentityAndEligibilityResponse.builder()
+                .identityStatus(IdentityOutcome.MATCHED)
+                .eligibilityStatus(EligibilityOutcome.CONFIRMED)
+                .qualifyingBenefits(QualifyingBenefits.NOT_SET)
+                .mobilePhoneMatch(VerificationOutcome.NOT_SET)
+                .emailAddressMatch(VerificationOutcome.NOT_SET)
+                .addressLine1Match(VerificationOutcome.NOT_MATCHED)
+                .postcodeMatch(VerificationOutcome.MATCHED)
+                .pregnantChildDOBMatch(VerificationOutcome.NOT_SET)
+                .householdIdentifier(null)
+                .dobOfChildrenUnder4(Collections.emptyList())
+                .deathVerificationFlag(DeathVerificationFlag.N_A)
+                .build();
+    }
+
+    public static IdentityAndEligibilityResponse anIdentityMatchedEligibilityConfirmedUCResponseWithMatches(VerificationOutcome mobileVerification,
+                                                                                                            VerificationOutcome emailVerification,
+                                                                                                            List<LocalDate> childrenDobs) {
+        return IdentityAndEligibilityResponse.builder()
+                .identityStatus(IdentityOutcome.MATCHED)
+                .eligibilityStatus(EligibilityOutcome.CONFIRMED)
+                .qualifyingBenefits(QualifyingBenefits.UNIVERSAL_CREDIT)
+                .mobilePhoneMatch(mobileVerification)
+                .emailAddressMatch(emailVerification)
+                .addressLine1Match(VerificationOutcome.MATCHED)
+                .postcodeMatch(VerificationOutcome.MATCHED)
+                .pregnantChildDOBMatch(VerificationOutcome.NOT_SET)
+                .householdIdentifier(null)
+                .deathVerificationFlag(DeathVerificationFlag.N_A)
+                .dobOfChildrenUnder4(childrenDobs)
+                .build();
+    }
+
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/helper/v2/PersonDTOV2TestDataFactory.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/helper/v2/PersonDTOV2TestDataFactory.java
@@ -20,6 +20,10 @@ public class PersonDTOV2TestDataFactory {
         return validPersonBuilder().nino(nino).build();
     }
 
+    public static PersonDTOV2 aPersonDTOV2WithSurnameAndNino(String surname, String nino) {
+        return validPersonBuilder().surname(surname).nino(nino).build();
+    }
+
     public static PersonDTOV2 aPersonDTOV2WithPostcode(String postcode) {
         return validPersonBuilder().postcode(postcode).build();
     }

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/service/v2/IdentityAndEligibilityServiceTest.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/service/v2/IdentityAndEligibilityServiceTest.java
@@ -1,0 +1,105 @@
+package uk.gov.dhsc.htbhf.smartstub.service.v2;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.dhsc.htbhf.smartstub.model.v2.DWPEligibilityRequestV2;
+import uk.gov.dhsc.htbhf.smartstub.model.v2.IdentityAndEligibilityResponse;
+import uk.gov.dhsc.htbhf.smartstub.model.v2.PersonDTOV2;
+import uk.gov.dhsc.htbhf.smartstub.model.v2.VerificationOutcome;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.dhsc.htbhf.smartstub.helper.TestConstants.*;
+import static uk.gov.dhsc.htbhf.smartstub.helper.v2.DWPEligibilityRequestV2TestDataFactory.aValidDWPEligibilityRequestV2WithPerson;
+import static uk.gov.dhsc.htbhf.smartstub.helper.v2.IdentityAndEligibilityResponseTestDataFactory.*;
+import static uk.gov.dhsc.htbhf.smartstub.helper.v2.PersonDTOV2TestDataFactory.aPersonDTOV2WithNino;
+import static uk.gov.dhsc.htbhf.smartstub.helper.v2.PersonDTOV2TestDataFactory.aPersonDTOV2WithSurnameAndNino;
+
+@Disabled
+class IdentityAndEligibilityServiceTest {
+
+    private static final String IDENTITY_MATCH_FAILED_NINO = "QQ123456A";
+    private static final String IDENTITY_MATCHED_NOT_ELIGIBLE_NINO = "MN123456A";
+    private static final String IDENTITY_MATCHED_ELIGIBILITY_CONFIRMED_NINO = "MC999999A";
+    private static final String IDENTITY_MATCHED_ELIGIBILITY_CONFIRMED_PARTIAL_CHILDREN_MATCH_NINO = "MC219999A";
+    private static final String IDENTITY_MATCHED_ELIGIBILITY_CONFIRMED_FULL_CHILDREN_MATCH_NINO = "MC129999A";
+
+    private IdentityAndEligibilityService service = new IdentityAndEligibilityService();
+
+    @Test
+    void shouldFailIdentityMatch() {
+        PersonDTOV2 person = aPersonDTOV2WithNino(IDENTITY_MATCH_FAILED_NINO);
+        IdentityAndEligibilityResponse expectedResponse = anIdentityMatchFailedResponse();
+        runEvaluateEligibilityTest(person, expectedResponse);
+    }
+
+    @Test
+    void shouldReturnIdentityMatchedEligibilityNotConfirmed() {
+        PersonDTOV2 person = aPersonDTOV2WithNino(IDENTITY_MATCHED_NOT_ELIGIBLE_NINO);
+        IdentityAndEligibilityResponse expectedResponse = anIdentityMatchedEligibilityNotConfirmedResponse();
+        runEvaluateEligibilityTest(person, expectedResponse);
+    }
+
+    @Test
+    void shouldReturnIdentityMatchedEligibilityConfirmedAddressNotMatched() {
+        PersonDTOV2 person = aPersonDTOV2WithSurnameAndNino(ADDRESS_LINE_ONE_NOT_MATCHED_SURNAME, IDENTITY_MATCHED_ELIGIBILITY_CONFIRMED_NINO);
+        IdentityAndEligibilityResponse expectedResponse = anIdentityMatchedEligibilityConfirmedAddressNotMatchedResponse();
+        runEvaluateEligibilityTest(person, expectedResponse);
+    }
+
+    @Test
+    void shouldReturnIdentityMatchedEligibilityConfirmedPostcodeNotMatched() {
+        //Given
+        PersonDTOV2 person = aPersonDTOV2WithSurnameAndNino(POSTCODE_NOT_MATCHED_SURNAME, IDENTITY_MATCHED_ELIGIBILITY_CONFIRMED_NINO);
+        IdentityAndEligibilityResponse expectedResponse = anIdentityMatchedEligibilityConfirmedPostcodeNotMatchedResponse();
+        runEvaluateEligibilityTest(person, expectedResponse);
+    }
+
+    @ParameterizedTest(name = "Surname={0}, mobile outcome={1}, email outcome={2}")
+    @MethodSource("verificationOutcomeForSurnameArguments")
+    void shouldReturnIdentityMatchedEligibilityConfirmedPartialChildrenMatch(String surname,
+                                                                             VerificationOutcome mobileMatchOutcome,
+                                                                             VerificationOutcome emailMatchOutcome) {
+        PersonDTOV2 person = aPersonDTOV2WithSurnameAndNino(surname, IDENTITY_MATCHED_ELIGIBILITY_CONFIRMED_PARTIAL_CHILDREN_MATCH_NINO);
+        IdentityAndEligibilityResponse expectedResponse = anIdentityMatchedEligibilityConfirmedUCResponseWithMatches(mobileMatchOutcome,
+                emailMatchOutcome, SINGLE_THREE_YEAR_OLD);
+        runEvaluateEligibilityTest(person, expectedResponse);
+    }
+
+    @ParameterizedTest(name = "Surname={0}, mobile outcome={1}, email outcome={2}")
+    @MethodSource("verificationOutcomeForSurnameArguments")
+    void shouldReturnIdentityMatchedEligibilityConfirmedFullChildrenMatch(String surname,
+                                                                          VerificationOutcome mobileMatchOutcome,
+                                                                          VerificationOutcome emailMatchOutcome) {
+        PersonDTOV2 person = aPersonDTOV2WithSurnameAndNino(surname, IDENTITY_MATCHED_ELIGIBILITY_CONFIRMED_FULL_CHILDREN_MATCH_NINO);
+        IdentityAndEligibilityResponse expectedResponse = anIdentityMatchedEligibilityConfirmedUCResponseWithMatches(mobileMatchOutcome,
+                emailMatchOutcome, TWO_CHILDREN);
+        runEvaluateEligibilityTest(person, expectedResponse);
+    }
+
+    private void runEvaluateEligibilityTest(PersonDTOV2 person, IdentityAndEligibilityResponse expectedResponse) {
+        //Given
+        DWPEligibilityRequestV2 requestV2 = aValidDWPEligibilityRequestV2WithPerson(person);
+        //When
+        IdentityAndEligibilityResponse response = service.evaluateEligibility(requestV2);
+        //Then
+        assertThat(response).isEqualTo(expectedResponse);
+    }
+
+    //Arguments are Surname, Mobile Match, Email Match
+    private static Stream<Arguments> verificationOutcomeForSurnameArguments() {
+        return Stream.of(
+                Arguments.of(MOBILE_NOT_HELD_SURNAME, VerificationOutcome.NOT_HELD, VerificationOutcome.MATCHED),
+                Arguments.of(EMAIL_NOT_HELD_SURNAME, VerificationOutcome.MATCHED, VerificationOutcome.NOT_HELD),
+                Arguments.of(MOBILE_AND_EMAIL_NOT_HELD_SURNAME, VerificationOutcome.NOT_HELD, VerificationOutcome.NOT_HELD),
+                Arguments.of(MOBILE_NOT_MATCHED_SURNAME, VerificationOutcome.NOT_MATCHED, VerificationOutcome.MATCHED),
+                Arguments.of(EMAIL_NOT_MATCHED_SURNAME, VerificationOutcome.MATCHED, VerificationOutcome.NOT_MATCHED),
+                Arguments.of(MOBILE_AND_EMAIL_NOT_MATCHED_SURNAME, VerificationOutcome.NOT_MATCHED, VerificationOutcome.NOT_MATCHED)
+        );
+    }
+
+}


### PR DESCRIPTION
Currently no implementation, just wanted to get the unit tests in disabled. Was unsure whether to have mirror integration tests or whether just a couple of integration tests would do, any thoughts? I'll do those once the implementation is in place anyway.

The tests should mirror the spreadsheet I added to the technical channel in Slack plus what is on the whiteboard (if its still there) so please look at that if you're unsure what is correct or not.

I will add JavaDoc to the service as a part of the implementation PR.