### PR TITLE
HTBHF-2509 Add implementation for IdentityAndEligibilityService including README.md documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # htbhf-smart-stub
 Service for stubbing out DWP and Card Service provider apis.
 
-## Benefit Eligibility Stubbing
+## V1 Benefit Eligibility Stubbing
 The service returns stubbed responses depending on the national insurance number (nino) which is sent in the request.
 The nino is encoded as follows:
 
@@ -33,6 +33,37 @@ then the stub will return the same value for children under 1 and children under
 * The NINO ZZ999999D can be used if you want to trigger an error within the Smart stub, which will in turn return a 500 response.
 
 The household identifier value is a Base64 generated value based on the NINO.
+
+## V2 Benefit Eligibility and Identity Checking Stubbing
+
+The service returns stubbed responses depending on the national insurance number (NINO) and surname which is sent in the request.
+The NINO is encoded as follows:
+
+ * The first character of the NINO is used to determine the Identity Status:
+   * If the NINO starts with M the identity status is MATCHED, otherwise NOT_MATCHED
+ * The second character of the NINO is used to determine the Eligibility Status:
+   * If the second character of the NINO is N the eligibility status is NOT_CONFIRMED
+   * If the second character of the NINO is C the eligibility status is CONFIRMED
+ * There are 4 verification outcomes specified in the response, `AddressLine1Verification`, `PostcodeVerification`, `MobileVerification` 
+ and `EmailVerification`. The surname is then used to determine these verification outcomes as such:
+   * A surname of `AddressLineOneNotMatched` returns NOT_MATCHED for `AddressLine1Verification`, MATCHED for `PostcodeVerification` and NOT_SET for other verification outcomes
+   * A surname of `PostcodeNotMatched` returns NOT_MATCHED for `PostcodeVerification`, MATCHED for `AddressLine1Verification` and NOT_SET for other verification outcomes
+   * A surname of `MobileNotHeld` returns NOT_HELD for `MobileVerification` and MATCHED for other verification outcomes
+   * A surname of `EmailNotHeld` returns NOT_HELD for `EmailVerification` and MATCHED for other verification outcomes
+   * A surname of `MobileAndEmailNotHeld` returns NOT_HELD for both `EmailVerification` and `MobileVerification` and MATCHED for other verification outcomes
+   * A surname of `MobileNotMatched` returns NOT_MATCHED for `MobileVerification` and MATCHED for other verification outcomes
+   * A surname of `EmailNotMatched` returns NOT_MATCHED for `EmailVerification` and MATCHED for other verification outcomes
+   * A surname of `MobileAndEmailNotMatched` returns NOT_MATCHED for both `EmailVerification` and `MobileVerification` and MATCHED for other verification outcomes
+ * The `QualifyingBenefit` is only set if the Identity Status is matched, the Eligibility Status is confirmed and their address has
+  been matched. If this is the case then then `QualifyingBenefit` is set to `UNIVERSAL_CREDIT`.
+ * The dob of children under 4 is only set if they have a `QualifyingBenefit`.
+ * The first and second digits of the NINO are used to determine the dates of birth of children that will be returned:
+   * The first is the number of children under 1
+   * The second digit is the total number of children under 4 (including those under 1).
+   * If the second digit is smaller than the first digit, then a partial children match response is returned, which simply means
+   that we'll match the total number of children under 4 digit (2nd digit) and ignore the number of children under 1 digit (1st digit).
+  
+* The NINO XX999999D can be used if you want to trigger an error within the Smart stub, which will in turn return a 500 response.
 
 ## postman collection
 Use https://www.getpostman.com/collections/b1e8a55b936abd3879e3 to import a postman collection with api examples.

--- a/src/main/java/uk/gov/dhsc/htbhf/smartstub/service/v2/IdentityAndEligibilityService.java
+++ b/src/main/java/uk/gov/dhsc/htbhf/smartstub/service/v2/IdentityAndEligibilityService.java
@@ -1,11 +1,160 @@
 package uk.gov.dhsc.htbhf.smartstub.service.v2;
 
-import uk.gov.dhsc.htbhf.smartstub.model.v2.DWPEligibilityRequestV2;
-import uk.gov.dhsc.htbhf.smartstub.model.v2.IdentityAndEligibilityResponse;
+import lombok.extern.slf4j.Slf4j;
+import uk.gov.dhsc.htbhf.smartstub.model.v2.*;
 
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.nCopies;
+
+/**
+ * Component responsible for determining the identity and eligibility response for a request based
+ * in the NINO and Surname provided.
+ */
+@Slf4j
 public class IdentityAndEligibilityService {
 
+    public static final String EXCEPTION_NINO = "XX999999D";
+    private static final char MATCHED_CHAR = 'M';
+    private static final char ELIGIBILITY_CONFIRMED_CHAR = 'C';
+    private static final int IDENTITY_STATUS_POSITION = 0;
+    private static final int ELIGIBILITY_STATUS_POSITION = 1;
+    private static final int CHILDREN_UNDER_ONE_POSITION = 2;
+    private static final int CHILDREN_UNDER_FOUR_POSITION = 3;
+
+    public static final String ADDRESS_LINE_ONE_NOT_MATCHED_SURNAME = "AddressLineOneNotMatched";
+    public static final String POSTCODE_NOT_MATCHED_SURNAME = "PostcodeNotMatched";
+    public static final String MOBILE_NOT_HELD_SURNAME = "MobileNotHeld";
+    public static final String EMAIL_NOT_HELD_SURNAME = "EmailNotHeld";
+    public static final String MOBILE_AND_EMAIL_NOT_HELD_SURNAME = "MobileAndEmailNotHeld";
+    public static final String MOBILE_NOT_MATCHED_SURNAME = "MobileNotMatched";
+    public static final String EMAIL_NOT_MATCHED_SURNAME = "EmailNotMatched";
+    public static final String MOBILE_AND_EMAIL_NOT_MATCHED_SURNAME = "MobileAndEmailNotMatched";
+    private static final String NO_HOUSEHOLD_IDENTIFIER_PROVIDED = "";
+
+    /**
+     * Full details of the rules used to determine the response can be found in the README.md file.
+     *
+     * @param request The request to evaluate
+     * @return The response from the above criteria
+     */
     public IdentityAndEligibilityResponse evaluateEligibility(DWPEligibilityRequestV2 request) {
-        return null;
+
+        String nino = request.getPerson().getNino();
+        if (EXCEPTION_NINO.equals(nino)) {
+            String message = "NINO provided (" + EXCEPTION_NINO + ") has been configured to trigger an Exception";
+            log.info(message);
+            throw new IllegalArgumentException(message);
+        }
+        IdentityAndEligibilityResponse.IdentityAndEligibilityResponseBuilder builder = setupDefaultBuilder();
+        IdentityOutcome identityStatus = setIdentityStatus(nino, builder);
+        EligibilityOutcome eligibilityStatus = setEligibilityStatus(nino, identityStatus, builder);
+
+        if (IdentityOutcome.NOT_MATCHED == identityStatus || EligibilityOutcome.NOT_CONFIRMED == eligibilityStatus) {
+            return builder.build();
+        }
+
+        String surname = request.getPerson().getSurname();
+        setAddressVerificationOutcomes(surname, builder);
+
+        if (isAddressNotMatchedSurname(surname)) {
+            return builder.build();
+        }
+
+        builder.qualifyingBenefits(QualifyingBenefits.UNIVERSAL_CREDIT);
+        setEmailAndMobileVerificationOutcomes(builder, surname);
+        setDobOfChildrenUnder4(builder, nino);
+        return builder.build();
+    }
+
+    private void setDobOfChildrenUnder4(IdentityAndEligibilityResponse.IdentityAndEligibilityResponseBuilder builder, String nino) {
+        Integer childrenUnderFour = getNumberOfChildrenUnderFour(nino);
+        Integer childrenUnderOne = getNumberOfChildrenUnderOne(childrenUnderFour, nino);
+        builder.dobOfChildrenUnder4(createChildren(childrenUnderOne, childrenUnderFour));
+    }
+
+    private void setEmailAndMobileVerificationOutcomes(IdentityAndEligibilityResponse.IdentityAndEligibilityResponseBuilder builder, String surname) {
+        VerificationOutcomeForSurname verificationOutcomeForSurname = VerificationOutcomeForSurname.getVerificationOutcomesForSurname(surname);
+        builder.mobilePhoneMatch(verificationOutcomeForSurname.getMobileOutcome());
+        builder.emailAddressMatch(verificationOutcomeForSurname.getEmailOutcome());
+    }
+
+    private boolean isAddressNotMatchedSurname(String surname) {
+        return isAddressLine1NotMatchedSurname(surname) || isPostcodeNotMatchedSurname(surname);
+    }
+
+    private void setAddressVerificationOutcomes(String surname, IdentityAndEligibilityResponse.IdentityAndEligibilityResponseBuilder builder) {
+        if (isAddressLine1NotMatchedSurname(surname)) {
+            builder.addressLine1Match(VerificationOutcome.NOT_MATCHED);
+            builder.postcodeMatch(VerificationOutcome.MATCHED);
+        } else if (isPostcodeNotMatchedSurname(surname)) {
+            builder.addressLine1Match(VerificationOutcome.MATCHED);
+            builder.postcodeMatch(VerificationOutcome.NOT_MATCHED);
+        } else {
+            builder.addressLine1Match(VerificationOutcome.MATCHED);
+            builder.postcodeMatch(VerificationOutcome.MATCHED);
+        }
+    }
+
+    private List<LocalDate> createChildren(Integer numberOfChildrenUnderOne, Integer numberOfChildrenUnderFour) {
+        List<LocalDate> childrenUnderOne = nCopies(numberOfChildrenUnderOne, LocalDate.now().minusMonths(6));
+        List<LocalDate> childrenBetweenOneAndFour = nCopies(numberOfChildrenUnderFour - numberOfChildrenUnderOne, LocalDate.now().minusYears(3));
+        return Stream.concat(childrenUnderOne.stream(), childrenBetweenOneAndFour.stream()).collect(Collectors.toList());
+    }
+
+    private Integer getNumberOfChildrenUnderOne(Integer childrenUnderFour, String nino) {
+        Integer childrenUnderOne = Character.getNumericValue(nino.charAt(CHILDREN_UNDER_ONE_POSITION));
+        return (childrenUnderOne > childrenUnderFour) ? childrenUnderFour : childrenUnderOne;
+    }
+
+    private Integer getNumberOfChildrenUnderFour(String nino) {
+        return Character.getNumericValue(nino.charAt(CHILDREN_UNDER_FOUR_POSITION));
+    }
+
+    private boolean isAddressLine1NotMatchedSurname(String surname) {
+        return ADDRESS_LINE_ONE_NOT_MATCHED_SURNAME.equals(surname);
+    }
+
+    private boolean isPostcodeNotMatchedSurname(String surname) {
+        return POSTCODE_NOT_MATCHED_SURNAME.equals(surname);
+    }
+
+    private EligibilityOutcome setEligibilityStatus(String nino, IdentityOutcome identityStatus,
+                                                    IdentityAndEligibilityResponse.IdentityAndEligibilityResponseBuilder builder) {
+        EligibilityOutcome eligibilityStatus = determineEligibilityStatus(identityStatus, nino);
+        builder.eligibilityStatus(eligibilityStatus);
+        return eligibilityStatus;
+    }
+
+    private EligibilityOutcome determineEligibilityStatus(IdentityOutcome identityStatus, String nino) {
+        if (identityStatus == IdentityOutcome.NOT_MATCHED) {
+            return EligibilityOutcome.NOT_SET;
+        }
+        return (nino.charAt(ELIGIBILITY_STATUS_POSITION) == ELIGIBILITY_CONFIRMED_CHAR)
+                ? EligibilityOutcome.CONFIRMED : EligibilityOutcome.NOT_CONFIRMED;
+    }
+
+    private IdentityOutcome setIdentityStatus(String nino, IdentityAndEligibilityResponse.IdentityAndEligibilityResponseBuilder builder) {
+        IdentityOutcome identityStatus = (nino.charAt(IDENTITY_STATUS_POSITION) == MATCHED_CHAR)
+                ? IdentityOutcome.MATCHED : IdentityOutcome.NOT_MATCHED;
+        builder.identityStatus(identityStatus);
+        return identityStatus;
+    }
+
+    private IdentityAndEligibilityResponse.IdentityAndEligibilityResponseBuilder setupDefaultBuilder() {
+        return IdentityAndEligibilityResponse.builder()
+                .pregnantChildDOBMatch(VerificationOutcome.NOT_SET)
+                .qualifyingBenefits(QualifyingBenefits.NOT_SET)
+                .addressLine1Match(VerificationOutcome.NOT_SET)
+                .postcodeMatch(VerificationOutcome.NOT_SET)
+                .mobilePhoneMatch(VerificationOutcome.NOT_SET)
+                .emailAddressMatch(VerificationOutcome.NOT_SET)
+                .deathVerificationFlag(DeathVerificationFlag.N_A)
+                .householdIdentifier(NO_HOUSEHOLD_IDENTIFIER_PROVIDED)
+                .dobOfChildrenUnder4(emptyList());
     }
 }

--- a/src/main/java/uk/gov/dhsc/htbhf/smartstub/service/v2/VerificationOutcomeForSurname.java
+++ b/src/main/java/uk/gov/dhsc/htbhf/smartstub/service/v2/VerificationOutcomeForSurname.java
@@ -1,0 +1,43 @@
+package uk.gov.dhsc.htbhf.smartstub.service.v2;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import uk.gov.dhsc.htbhf.smartstub.model.v2.VerificationOutcome;
+
+import java.util.Arrays;
+
+import static uk.gov.dhsc.htbhf.smartstub.model.v2.VerificationOutcome.MATCHED;
+import static uk.gov.dhsc.htbhf.smartstub.model.v2.VerificationOutcome.NOT_HELD;
+import static uk.gov.dhsc.htbhf.smartstub.model.v2.VerificationOutcome.NOT_MATCHED;
+import static uk.gov.dhsc.htbhf.smartstub.service.v2.IdentityAndEligibilityService.*;
+
+@Getter
+@AllArgsConstructor
+public enum VerificationOutcomeForSurname {
+
+    MOBILE_NOT_HELD(MOBILE_NOT_HELD_SURNAME, NOT_HELD, MATCHED),
+    EMAIL_NOT_HELD(EMAIL_NOT_HELD_SURNAME, MATCHED, NOT_HELD),
+    MOBILE_AND_EMAIL_NOT_HELD(MOBILE_AND_EMAIL_NOT_HELD_SURNAME, NOT_HELD, NOT_HELD),
+    MOBILE_NOT_MATCHED(MOBILE_NOT_MATCHED_SURNAME, NOT_MATCHED, MATCHED),
+    EMAIL_NOT_MATCHED(EMAIL_NOT_MATCHED_SURNAME, MATCHED, NOT_MATCHED),
+    MOBILE_AND_EMAIL_NOT_MATCHED(MOBILE_AND_EMAIL_NOT_MATCHED_SURNAME, NOT_MATCHED, NOT_MATCHED),
+    DEFAULT("", MATCHED, MATCHED);
+
+    private String surname;
+    private VerificationOutcome mobileOutcome;
+    private VerificationOutcome emailOutcome;
+
+    /**
+     * Get the enum value matching the provided surname, or default to a response which has both outcomes being matched.
+     *
+     * @param surname The surname to match.
+     * @return The outcome for both mobile and email.
+     */
+    public static VerificationOutcomeForSurname getVerificationOutcomesForSurname(String surname) {
+        return Arrays.stream(VerificationOutcomeForSurname.values())
+                .filter(verificationOutcomeForSurname -> verificationOutcomeForSurname.getSurname().equals(surname))
+                .findFirst()
+                .orElse(DEFAULT);
+    }
+
+}

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/helper/TestConstants.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/helper/TestConstants.java
@@ -18,24 +18,16 @@ public final class TestConstants {
     public static final String MAGGIE_DATE_OF_BIRTH_STRING = "1985-12-31";
     public static final LocalDate MAGGIE_DATE_OF_BIRTH = LocalDate.parse("1985-12-31");
     public static final int UC_MONTHLY_INCOME_THRESHOLD = 40800;
-    public static final String HOUSEHOLD_IDENTIFIER = "household1";
+    public static final String NO_HOUSEHOLD_IDENTIFIER_PROVIDED = "";
 
     public static final String SIMPSONS_ADDRESS_LINE_1 = "742 Evergreen Terrace";
     public static final String SIMPSONS_ADDRESS_LINE_2 = "Mystery Spot";
     public static final String SIMPSONS_TOWN = "Springfield";
     public static final String SIMPSONS_POSTCODE = "AA1 1AA";
 
-    public static final String ADDRESS_LINE_ONE_NOT_MATCHED_SURNAME = "AddressLineOneNotMatched";
-    public static final String POSTCODE_NOT_MATCHED_SURNAME = "PostcodeNotMatched";
-    public static final String MOBILE_NOT_HELD_SURNAME = "MobileNotHeld";
-    public static final String EMAIL_NOT_HELD_SURNAME = "EmailNotHeld";
-    public static final String MOBILE_AND_EMAIL_NOT_HELD_SURNAME = "MobileAndEmailNotHeld";
-    public static final String MOBILE_NOT_MATCHED_SURNAME = "MobileNotMatched";
-    public static final String EMAIL_NOT_MATCHED_SURNAME = "EmailNotMatched";
-    public static final String MOBILE_AND_EMAIL_NOT_MATCHED_SURNAME = "MobileAndEmailNotMatched";
-
     public static final LocalDate SIX_MONTH_OLD = LocalDate.now().minusMonths(6);
     public static final LocalDate THREE_YEAR_OLD = LocalDate.now().minusYears(3);
     public static final List<LocalDate> TWO_CHILDREN = asList(SIX_MONTH_OLD, THREE_YEAR_OLD);
     public static final List<LocalDate> SINGLE_THREE_YEAR_OLD = singletonList(THREE_YEAR_OLD);
+    public static final List<LocalDate> SINGLE_SIX_MONTH_OLD = singletonList(SIX_MONTH_OLD);
 }

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/helper/v2/IdentityAndEligibilityResponseTestDataFactory.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/helper/v2/IdentityAndEligibilityResponseTestDataFactory.java
@@ -3,10 +3,10 @@ package uk.gov.dhsc.htbhf.smartstub.helper.v2;
 import uk.gov.dhsc.htbhf.smartstub.model.v2.*;
 
 import java.time.LocalDate;
-import java.util.Collections;
 import java.util.List;
 
-import static uk.gov.dhsc.htbhf.smartstub.helper.TestConstants.HOUSEHOLD_IDENTIFIER;
+import static java.util.Collections.emptyList;
+import static uk.gov.dhsc.htbhf.smartstub.helper.TestConstants.NO_HOUSEHOLD_IDENTIFIER_PROVIDED;
 
 public class IdentityAndEligibilityResponseTestDataFactory {
 
@@ -20,8 +20,8 @@ public class IdentityAndEligibilityResponseTestDataFactory {
                 .addressLine1Match(VerificationOutcome.NOT_SET)
                 .postcodeMatch(VerificationOutcome.NOT_SET)
                 .pregnantChildDOBMatch(VerificationOutcome.NOT_SET)
-                .householdIdentifier(null)
-                .dobOfChildrenUnder4(Collections.emptyList())
+                .householdIdentifier(NO_HOUSEHOLD_IDENTIFIER_PROVIDED)
+                .dobOfChildrenUnder4(emptyList())
                 .deathVerificationFlag(DeathVerificationFlag.N_A)
                 .build();
     }
@@ -36,8 +36,8 @@ public class IdentityAndEligibilityResponseTestDataFactory {
                 .addressLine1Match(VerificationOutcome.NOT_SET)
                 .postcodeMatch(VerificationOutcome.NOT_SET)
                 .pregnantChildDOBMatch(VerificationOutcome.NOT_SET)
-                .householdIdentifier(null)
-                .dobOfChildrenUnder4(Collections.emptyList())
+                .householdIdentifier(NO_HOUSEHOLD_IDENTIFIER_PROVIDED)
+                .dobOfChildrenUnder4(emptyList())
                 .deathVerificationFlag(DeathVerificationFlag.N_A)
                 .build();
     }
@@ -52,8 +52,8 @@ public class IdentityAndEligibilityResponseTestDataFactory {
                 .addressLine1Match(VerificationOutcome.MATCHED)
                 .postcodeMatch(VerificationOutcome.NOT_MATCHED)
                 .pregnantChildDOBMatch(VerificationOutcome.NOT_SET)
-                .householdIdentifier(null)
-                .dobOfChildrenUnder4(Collections.emptyList())
+                .householdIdentifier(NO_HOUSEHOLD_IDENTIFIER_PROVIDED)
+                .dobOfChildrenUnder4(emptyList())
                 .deathVerificationFlag(DeathVerificationFlag.N_A)
                 .build();
     }
@@ -68,8 +68,8 @@ public class IdentityAndEligibilityResponseTestDataFactory {
                 .addressLine1Match(VerificationOutcome.NOT_MATCHED)
                 .postcodeMatch(VerificationOutcome.MATCHED)
                 .pregnantChildDOBMatch(VerificationOutcome.NOT_SET)
-                .householdIdentifier(null)
-                .dobOfChildrenUnder4(Collections.emptyList())
+                .householdIdentifier(NO_HOUSEHOLD_IDENTIFIER_PROVIDED)
+                .dobOfChildrenUnder4(emptyList())
                 .deathVerificationFlag(DeathVerificationFlag.N_A)
                 .build();
     }
@@ -86,7 +86,23 @@ public class IdentityAndEligibilityResponseTestDataFactory {
                 .addressLine1Match(VerificationOutcome.MATCHED)
                 .postcodeMatch(VerificationOutcome.MATCHED)
                 .pregnantChildDOBMatch(VerificationOutcome.NOT_SET)
-                .householdIdentifier(null)
+                .householdIdentifier(NO_HOUSEHOLD_IDENTIFIER_PROVIDED)
+                .deathVerificationFlag(DeathVerificationFlag.N_A)
+                .dobOfChildrenUnder4(childrenDobs)
+                .build();
+    }
+
+    public static IdentityAndEligibilityResponse anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(List<LocalDate> childrenDobs) {
+        return IdentityAndEligibilityResponse.builder()
+                .identityStatus(IdentityOutcome.MATCHED)
+                .eligibilityStatus(EligibilityOutcome.CONFIRMED)
+                .qualifyingBenefits(QualifyingBenefits.UNIVERSAL_CREDIT)
+                .mobilePhoneMatch(VerificationOutcome.MATCHED)
+                .emailAddressMatch(VerificationOutcome.MATCHED)
+                .addressLine1Match(VerificationOutcome.MATCHED)
+                .postcodeMatch(VerificationOutcome.MATCHED)
+                .pregnantChildDOBMatch(VerificationOutcome.NOT_SET)
+                .householdIdentifier(NO_HOUSEHOLD_IDENTIFIER_PROVIDED)
                 .deathVerificationFlag(DeathVerificationFlag.N_A)
                 .dobOfChildrenUnder4(childrenDobs)
                 .build();

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/model/v2/PersonDTOV2Test.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/model/v2/PersonDTOV2Test.java
@@ -49,7 +49,8 @@ class PersonDTOV2Test extends AbstractValidationTest {
             "888888888",
             "ABCDEFGHI",
             "ZQQ123456CZ",
-            "QQ123456T"
+            "QQ123456T",
+            "ZZ999999D"
     })
     void shouldFailValidationWithInvalidNino(String nino) {
         PersonDTOV2 personDTOV2 = aPersonDTOV2WithNino(nino);

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/service/v2/VerificationOutcomeForSurnameTest.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/service/v2/VerificationOutcomeForSurnameTest.java
@@ -1,0 +1,59 @@
+package uk.gov.dhsc.htbhf.smartstub.service.v2;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import uk.gov.dhsc.htbhf.smartstub.model.v2.VerificationOutcome;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.dhsc.htbhf.smartstub.service.v2.IdentityAndEligibilityService.*;
+
+class VerificationOutcomeForSurnameTest {
+
+    @ParameterizedTest(name = "Surname={0}, Mobile outcome={1}, Email outcome={2}")
+    @MethodSource("verificationOutcomeArguments")
+    void shouldGetVerificationOutcomesForSpecifiedSurname(String surname,
+                                                          VerificationOutcome mobileVerificationOutcome,
+                                                          VerificationOutcome emailVerificationOutcome) {
+        //When
+        VerificationOutcomeForSurname verificationOutcomeForSurname = VerificationOutcomeForSurname.getVerificationOutcomesForSurname(surname);
+        //Then
+        assertThat(verificationOutcomeForSurname.getEmailOutcome()).isEqualTo(emailVerificationOutcome);
+        assertThat(verificationOutcomeForSurname.getMobileOutcome()).isEqualTo(mobileVerificationOutcome);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "Simpson", "Other"})
+    void shouldGetDefaultVerificationOutcomesForUnknownSurname(String surname) {
+        //When
+        VerificationOutcomeForSurname verificationOutcomeForSurname = VerificationOutcomeForSurname.getVerificationOutcomesForSurname(surname);
+        //Then
+        assertThat(verificationOutcomeForSurname.getEmailOutcome()).isEqualTo(VerificationOutcome.MATCHED);
+        assertThat(verificationOutcomeForSurname.getMobileOutcome()).isEqualTo(VerificationOutcome.MATCHED);
+    }
+
+    @Test
+    void shouldGetDefaultVerificationOutcomesForNullSurname() {
+        //When
+        VerificationOutcomeForSurname verificationOutcomeForSurname = VerificationOutcomeForSurname.getVerificationOutcomesForSurname(null);
+        //Then
+        assertThat(verificationOutcomeForSurname.getEmailOutcome()).isEqualTo(VerificationOutcome.MATCHED);
+        assertThat(verificationOutcomeForSurname.getMobileOutcome()).isEqualTo(VerificationOutcome.MATCHED);
+    }
+
+
+    private static Stream<Arguments> verificationOutcomeArguments() {
+        return Stream.of(
+                Arguments.of(MOBILE_NOT_HELD_SURNAME, VerificationOutcome.NOT_HELD, VerificationOutcome.MATCHED),
+                Arguments.of(EMAIL_NOT_HELD_SURNAME, VerificationOutcome.MATCHED, VerificationOutcome.NOT_HELD),
+                Arguments.of(MOBILE_AND_EMAIL_NOT_HELD_SURNAME, VerificationOutcome.NOT_HELD, VerificationOutcome.NOT_HELD),
+                Arguments.of(MOBILE_NOT_MATCHED_SURNAME, VerificationOutcome.NOT_MATCHED, VerificationOutcome.MATCHED),
+                Arguments.of(EMAIL_NOT_MATCHED_SURNAME, VerificationOutcome.MATCHED, VerificationOutcome.NOT_MATCHED),
+                Arguments.of(MOBILE_AND_EMAIL_NOT_MATCHED_SURNAME, VerificationOutcome.NOT_MATCHED, VerificationOutcome.NOT_MATCHED)
+        );
+    }
+}


### PR DESCRIPTION
 - Added implementation of service to match stubbing from whiteboard session.
 - Added enum to match the surname to verification outcomes
 - Added failing NINO as per v1, although a NINO starting with ZZ is not allowed according to the regex validation, so have now used XX999999D instead.
 - Added extra unit test for service to make sure a request for a woman with no children still works (NINO of MC009999D).