### PR TITLE
HTBHF-2528 Modify the dates of birth of the children return so that they are predictable for testing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ The NINO is encoded as follows:
    * The second digit is the total number of children under 4 (including those under 1).
    * If the second digit is smaller than the first digit, then a partial children match response is returned, which simply means
    that we'll match the total number of children under 4 digit (2nd digit) and ignore the number of children under 1 digit (1st digit).
+   * The dates of birth returned will be as such:
+     * Any children under 1 will have a birth day of the first day of the month 6 months ago. e.g. If today is 31 Oct 2019, the date of birth returned
+     for a child under 1 will be 01 Apr 2019. This will be the same for all children under 1.
+     * Any children between 1 and 4 will similarly have a date of birth of the first day of the month 3 years ago. e.g. If today is 31 Oct 2019, the
+     date of birth returned will be 01 Oct 2016 for all children.
   
 * The NINO XX999999D can be used if you want to trigger an error within the Smart stub, which will in turn return a 500 response.
 

--- a/src/main/java/uk/gov/dhsc/htbhf/smartstub/service/v2/IdentityAndEligibilityService.java
+++ b/src/main/java/uk/gov/dhsc/htbhf/smartstub/service/v2/IdentityAndEligibilityService.java
@@ -108,9 +108,21 @@ public class IdentityAndEligibilityService {
     }
 
     private List<LocalDate> createChildren(Integer numberOfChildrenUnderOne, Integer numberOfChildrenUnderFour) {
-        List<LocalDate> childrenUnderOne = nCopies(numberOfChildrenUnderOne, LocalDate.now().minusMonths(6));
-        List<LocalDate> childrenBetweenOneAndFour = nCopies(numberOfChildrenUnderFour - numberOfChildrenUnderOne, LocalDate.now().minusYears(3));
+        List<LocalDate> childrenUnderOne = nCopies(numberOfChildrenUnderOne, getDateOfBirthOfUnderOneYearOld());
+        List<LocalDate> childrenBetweenOneAndFour = nCopies(numberOfChildrenUnderFour - numberOfChildrenUnderOne, getDateOfBirthOfThreeYearOld());
         return Stream.concat(childrenUnderOne.stream(), childrenBetweenOneAndFour.stream()).collect(Collectors.toList());
+    }
+
+    // We always make sure that there is no ambiguity over the date by setting it to the
+    // first day of the month 6 months ago.
+    private LocalDate getDateOfBirthOfUnderOneYearOld() {
+        return LocalDate.now().minusMonths(6).withDayOfMonth(1);
+    }
+
+    // We always make sure that there is no ambiguity over the date by setting it to the
+    // first day of the month 3 years ago.
+    private LocalDate getDateOfBirthOfThreeYearOld() {
+        return LocalDate.now().minusYears(3).withDayOfMonth(1);
     }
 
     private Integer getNumberOfChildrenUnderOne(Integer childrenUnderFour, String nino) {

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/helper/TestConstants.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/helper/TestConstants.java
@@ -26,8 +26,8 @@ public final class TestConstants {
     public static final String SIMPSONS_TOWN = "Springfield";
     public static final String SIMPSONS_POSTCODE = "AA1 1AA";
 
-    public static final LocalDate SIX_MONTH_OLD = LocalDate.now().minusMonths(6);
-    public static final LocalDate THREE_YEAR_OLD = LocalDate.now().minusYears(3);
+    public static final LocalDate SIX_MONTH_OLD = LocalDate.now().minusMonths(6).withDayOfMonth(1);
+    public static final LocalDate THREE_YEAR_OLD = LocalDate.now().minusYears(3).withDayOfMonth(1);
     public static final List<LocalDate> TWO_CHILDREN = asList(SIX_MONTH_OLD, THREE_YEAR_OLD);
     public static final List<LocalDate> SINGLE_THREE_YEAR_OLD = singletonList(THREE_YEAR_OLD);
     public static final List<LocalDate> SINGLE_SIX_MONTH_OLD = singletonList(SIX_MONTH_OLD);


### PR DESCRIPTION
The dates will be the first of the month six months ago so there is no confusion over what it should be when its the 31st of a month that 6 months ago doesn't have a 31st day in that month.