### PR TITLE
HTBHF-2578 Add check for pregnant dependent DOB and set to NOT_SUPPLIED if not sent in request.

### DIFF
--- a/src/main/java/uk/gov/dhsc/htbhf/smartstub/service/v2/IdentityAndEligibilityService.java
+++ b/src/main/java/uk/gov/dhsc/htbhf/smartstub/service/v2/IdentityAndEligibilityService.java
@@ -71,7 +71,14 @@ public class IdentityAndEligibilityService {
         builder.qualifyingBenefits(QualifyingBenefits.UNIVERSAL_CREDIT);
         setEmailAndMobileVerificationOutcomes(builder, request.getPerson());
         setDobOfChildrenUnder4(builder, nino);
+        setPregnantChildDOBMatch(builder, request.getPerson());
         return builder.build();
+    }
+
+    private void setPregnantChildDOBMatch(IdentityAndEligibilityResponse.IdentityAndEligibilityResponseBuilder builder, PersonDTOV2 person) {
+        if (person.getPregnantDependentDob() == null) {
+            builder.pregnantChildDOBMatch(VerificationOutcome.NOT_SUPPLIED);
+        }
     }
 
     private void setDobOfChildrenUnder4(IdentityAndEligibilityResponse.IdentityAndEligibilityResponseBuilder builder, String nino) {

--- a/src/test/java/uk/gov/dhsc/htbhf/smartstub/service/v2/IdentityAndEligibilityServiceTest.java
+++ b/src/test/java/uk/gov/dhsc/htbhf/smartstub/service/v2/IdentityAndEligibilityServiceTest.java
@@ -9,9 +9,9 @@ import uk.gov.dhsc.htbhf.dwp.model.v2.IdentityAndEligibilityResponse;
 import uk.gov.dhsc.htbhf.dwp.model.v2.PersonDTOV2;
 import uk.gov.dhsc.htbhf.dwp.model.v2.VerificationOutcome;
 
-import java.util.Collections;
 import java.util.stream.Stream;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static uk.gov.dhsc.htbhf.dwp.testhelper.TestConstants.SIMPSON_SURNAME;
@@ -19,10 +19,7 @@ import static uk.gov.dhsc.htbhf.dwp.testhelper.TestConstants.SINGLE_SIX_MONTH_OL
 import static uk.gov.dhsc.htbhf.dwp.testhelper.TestConstants.TWO_CHILDREN;
 import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.DWPEligibilityRequestV2TestDataFactory.aValidDWPEligibilityRequestV2WithPerson;
 import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.IdentityAndEligibilityResponseTestDataFactory.*;
-import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.PersonDTOV2TestDataFactory.aPersonDTOV2WithNino;
-import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.PersonDTOV2TestDataFactory.aPersonDTOV2WithSurnameAndEmail;
-import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.PersonDTOV2TestDataFactory.aPersonDTOV2WithSurnameAndMobile;
-import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.PersonDTOV2TestDataFactory.aPersonDTOV2WithSurnameAndNino;
+import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.PersonDTOV2TestDataFactory.*;
 import static uk.gov.dhsc.htbhf.smartstub.service.v2.IdentityAndEligibilityService.*;
 
 class IdentityAndEligibilityServiceTest {
@@ -68,7 +65,15 @@ class IdentityAndEligibilityServiceTest {
     @Test
     void shouldReturnIdentityMatchedEligibilityConfirmedForPregnantWomanWithNoChildren() {
         PersonDTOV2 person = aPersonDTOV2WithSurnameAndNino(SIMPSON_SURNAME, IDENTITY_MATCHED_ELIGIBILITY_CONFIRMED_NO_CHILDREN_NINO);
-        IdentityAndEligibilityResponse expectedResponse = anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(Collections.emptyList());
+        IdentityAndEligibilityResponse expectedResponse = anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(emptyList());
+        runEvaluateEligibilityTest(person, expectedResponse);
+    }
+
+    @Test
+    void shouldReturnIdentityMatchedEligibilityConfirmedPregnantDependentNotProvidedChildren() {
+        PersonDTOV2 person = aPersonDTOV2WithPregnantDependantDob(null);
+        IdentityAndEligibilityResponse expectedResponse = anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(VerificationOutcome.NOT_SUPPLIED,
+                TWO_CHILDREN);
         runEvaluateEligibilityTest(person, expectedResponse);
     }
 


### PR DESCRIPTION
The default is still NOT_SET, but if nothing is provided in the request then it will be NOT_SUPPLIED. This will at least help us in verifying that the field is being sent successfully to the smart stub.